### PR TITLE
Erros tipados

### DIFF
--- a/nfe/Cargo.toml
+++ b/nfe/Cargo.toml
@@ -17,3 +17,4 @@ chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_repr = "0.1"
 serde-xml-rs = "0.4.1"
+thiserror = "1.0.26"

--- a/nfe/Cargo.toml
+++ b/nfe/Cargo.toml
@@ -17,4 +17,4 @@ chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_repr = "0.1"
 serde-xml-rs = "0.4.1"
-thiserror = "1.0.26"
+derive_more = "0.99.16"

--- a/nfe/src/base/dest.rs
+++ b/nfe/src/base/dest.rs
@@ -1,6 +1,7 @@
 //! Destinarário da NF-e
 
 use super::endereco::*;
+use super::Error;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
 use std::str::FromStr;
@@ -33,9 +34,9 @@ pub enum IndicadorContribuicaoIe {
 }
 
 impl FromStr for Destinatario {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/emit.rs
+++ b/nfe/src/base/emit.rs
@@ -1,6 +1,7 @@
 //! Emitente da NF-e
 
 use super::endereco::*;
+use super::Error;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -22,9 +23,9 @@ pub struct Emitente {
 }
 
 impl FromStr for Emitente {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/endereco.rs
+++ b/nfe/src/base/endereco.rs
@@ -1,5 +1,6 @@
 //! Endereço do emitente/destinatário da NF-e
 
+use super::Error;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -27,9 +28,9 @@ pub struct Endereco {
 }
 
 impl FromStr for Endereco {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/error.rs
+++ b/nfe/src/base/error.rs
@@ -1,0 +1,17 @@
+//! Erros de parse, io...
+
+use thiserror::Error as ThisError;
+
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Falha na leitura do arquivo: {0}")]
+    Io(std::io::Error),
+    #[error("Falha no parse: {0}")]
+    Serde(serde_xml_rs::Error),
+}
+
+impl From<serde_xml_rs::Error> for Error {
+    fn from(se: serde_xml_rs::Error) -> Self {
+        Self::Serde(se)
+    }
+}

--- a/nfe/src/base/error.rs
+++ b/nfe/src/base/error.rs
@@ -1,17 +1,11 @@
 //! Erros de parse, io...
 
-use thiserror::Error as ThisError;
+use derive_more::{Display, Error, From};
 
-#[derive(Debug, ThisError)]
+#[derive(Debug, Display, Error, From)]
 pub enum Error {
-    #[error("Falha na leitura do arquivo: {0}")]
+    #[display(fmt = "Falha na leitura do arquivo: {}", _0)]
     Io(std::io::Error),
-    #[error("Falha no parse: {0}")]
+    #[display(fmt = "Falha no parse: {}", _0)]
     Serde(serde_xml_rs::Error),
-}
-
-impl From<serde_xml_rs::Error> for Error {
-    fn from(se: serde_xml_rs::Error) -> Self {
-        Self::Serde(se)
-    }
 }

--- a/nfe/src/base/ide/emissao.rs
+++ b/nfe/src/base/ide/emissao.rs
@@ -1,5 +1,6 @@
 //! Dados da emissão da NF-e
 
+use super::Error;
 use chrono::prelude::*;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
@@ -67,9 +68,9 @@ pub enum TipoProcessoEmissao {
 }
 
 impl FromStr for Emissao {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/ide/mod.rs
+++ b/nfe/src/base/ide/mod.rs
@@ -1,5 +1,6 @@
 //! Identificação da NF-e
 
+use super::Error;
 use chrono::prelude::*;
 use serde::{Deserialize, Deserializer};
 use serde_repr::Deserialize_repr;
@@ -62,10 +63,10 @@ pub struct ComposicaoChaveAcesso {
 }
 
 impl FromStr for Identificacao {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/ide/operacao.rs
+++ b/nfe/src/base/ide/operacao.rs
@@ -1,5 +1,6 @@
 //! Dados da operação da NF-e
 
+use super::Error;
 use chrono::prelude::*;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
@@ -80,9 +81,9 @@ pub enum TipoIntermediador {
 }
 
 impl FromStr for Operacao {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/item/imposto/mod.rs
+++ b/nfe/src/base/item/imposto/mod.rs
@@ -1,5 +1,6 @@
 //! Impostos dos itens
 
+use super::Error;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -29,9 +30,9 @@ pub struct Imposto {
 }
 
 impl FromStr for Imposto {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/item/mod.rs
+++ b/nfe/src/base/item/mod.rs
@@ -1,5 +1,6 @@
 //! Detalhamento de produtos e serviços
 
+use super::Error;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -22,9 +23,9 @@ pub struct Item {
 }
 
 impl FromStr for Item {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/item/produto.rs
+++ b/nfe/src/base/item/produto.rs
@@ -1,5 +1,6 @@
 //! Produtos
 
+use super::Error;
 use serde::{Deserialize, Deserializer};
 use serde_repr::Deserialize_repr;
 use std::str::FromStr;
@@ -71,10 +72,10 @@ pub enum EscalaRelevante {
 }
 
 impl FromStr for Produto {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/mod.rs
+++ b/nfe/src/base/mod.rs
@@ -11,12 +11,14 @@ use std::str::FromStr;
 pub mod dest;
 pub mod emit;
 pub mod endereco;
+mod error;
 pub mod ide;
 pub mod item;
 pub mod totais;
 pub mod transporte;
 use dest::Destinatario;
 use emit::Emitente;
+pub use error::Error;
 use ide::Identificacao;
 use item::Item;
 use totais::Totalizacao;
@@ -48,19 +50,19 @@ pub enum VersaoLayout {
 }
 
 impl FromStr for Nfe {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }
 
 impl TryFrom<File> for Nfe {
-    type Error = String;
+    type Error = Error;
 
     fn try_from(mut f: File) -> Result<Self, Self::Error> {
         let mut xml = String::new();
-        f.read_to_string(&mut xml).map_err(|e| e.to_string())?;
+        f.read_to_string(&mut xml).map_err(|e| Error::Io(e))?;
 
         xml.parse::<Nfe>()
     }

--- a/nfe/src/base/totais.rs
+++ b/nfe/src/base/totais.rs
@@ -1,5 +1,6 @@
 //! Totalização dos produtos e serviços
 
+use super::Error;
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
 
@@ -31,10 +32,10 @@ pub struct Totalizacao {
 }
 
 impl FromStr for Totalizacao {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/transporte.rs
+++ b/nfe/src/base/transporte.rs
@@ -1,5 +1,6 @@
 //! Informações sobre o transporte da nota
 
+use super::Error;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
 use std::str::FromStr;
@@ -14,10 +15,10 @@ pub struct Transporte {
 }
 
 impl FromStr for Transporte {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.to_string())
+        serde_xml_rs::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/modelos/nfe/dest.rs
+++ b/nfe/src/modelos/nfe/dest.rs
@@ -1,5 +1,6 @@
 //! Destinarário da NF-e no modelo 55
 
+use super::Error;
 use crate::base::dest::Destinatario as DestinatarioBase;
 pub use crate::base::dest::IndicadorContribuicaoIe;
 pub use crate::base::endereco::Endereco;
@@ -16,16 +17,16 @@ pub struct Destinatario {
 }
 
 impl TryFrom<DestinatarioBase> for Destinatario {
-    type Error = String;
+    type Error = Error;
 
     fn try_from(dest: DestinatarioBase) -> Result<Self, Self::Error> {
-        let razao_social = dest
-            .razao_social
-            .ok_or("Razão social/Nome não informado no destinatário")?;
+        let razao_social = dest.razao_social.ok_or_else(|| {
+            Error::DestinatarioInvalido("Razão social/Nome não informado".to_string())
+        })?;
 
         let endereco = dest
             .endereco
-            .ok_or("Endereço não informado no destinatário")?;
+            .ok_or_else(|| Error::DestinatarioInvalido("Endereço não informado".to_string()))?;
 
         Ok(Self {
             cnpj: dest.cnpj.clone(),
@@ -38,7 +39,7 @@ impl TryFrom<DestinatarioBase> for Destinatario {
 }
 
 impl FromStr for Destinatario {
-    type Err = String;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let base = s.parse::<DestinatarioBase>()?;

--- a/nfe/src/modelos/nfe/error.rs
+++ b/nfe/src/modelos/nfe/error.rs
@@ -1,19 +1,12 @@
 //! Erros referentes ao modelo 55
 
-use thiserror::Error as ThisError;
+use derive_more::{Display, Error, From};
 
-#[derive(Debug, ThisError)]
+#[derive(Debug, Display, Error, From)]
 pub enum Error {
-    #[error("Modelo do documento não suportado: {0:?}")]
-    ModeloInvalido(crate::ModeloDocumentoFiscal),
-    #[error("Destinatário inválido. {0}")]
-    DestinatarioInvalido(String),
-    #[error("{0}")]
+    #[display(fmt = "Modelo do documento não suportado: {:?}", _0)]
+    ModeloInvalido(#[error(not(source))] crate::ModeloDocumentoFiscal),
+    #[display(fmt = "Destinatário inválido. {}", _0)]
+    DestinatarioInvalido(#[error(not(source))] String),
     Base(crate::base::Error),
-}
-
-impl From<crate::base::Error> for Error {
-    fn from(bs: crate::base::Error) -> Self {
-        Self::Base(bs)
-    }
 }

--- a/nfe/src/modelos/nfe/error.rs
+++ b/nfe/src/modelos/nfe/error.rs
@@ -1,0 +1,19 @@
+//! Erros referentes ao modelo 55
+
+use thiserror::Error as ThisError;
+
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Modelo do documento não suportado: {0:?}")]
+    ModeloInvalido(crate::ModeloDocumentoFiscal),
+    #[error("Destinatário inválido. {0}")]
+    DestinatarioInvalido(String),
+    #[error("{0}")]
+    Base(crate::base::Error),
+}
+
+impl From<crate::base::Error> for Error {
+    fn from(bs: crate::base::Error) -> Self {
+        Self::Base(bs)
+    }
+}

--- a/nfe/src/tests/dest.rs
+++ b/nfe/src/tests/dest.rs
@@ -8,7 +8,7 @@ use crate::*;
 #[test]
 fn from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let dest = Nfe::try_from(f)?.dest;
+    let dest = Nfe::try_from(f).map_err(|e| e.to_string())?.dest;
 
     assert_eq!("58716523000119", dest.cnpj);
     assert_eq!(
@@ -31,7 +31,7 @@ fn from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn manual() -> Result<(), String> {
+fn manual() -> Result<(), Error> {
     let xml = "
         <dest>
             <CNPJ>58716523000119</CNPJ>

--- a/nfe/src/tests/emit.rs
+++ b/nfe/src/tests/emit.rs
@@ -8,7 +8,7 @@ use crate::*;
 #[test]
 fn from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let emit = Nfe::try_from(f)?.emit;
+    let emit = Nfe::try_from(f).map_err(|e| e.to_string())?.emit;
 
     assert_eq!("06929383000163", emit.cnpj);
     assert_eq!("UMA RAZAO SOCIAL DE TESTE QUALQUER", emit.razao_social);
@@ -29,7 +29,7 @@ fn from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn manual() -> Result<(), String> {
+fn manual() -> Result<(), Error> {
     let xml = "
         <emit>
             <CNPJ>06929383000163</CNPJ>
@@ -68,36 +68,6 @@ fn manual() -> Result<(), String> {
     assert_eq!("RS", emit.endereco.sigla_uf);
     assert_eq!(93800000, emit.endereco.cep);
     assert_eq!(Some("5190909090".to_string()), emit.endereco.telefone);
-
-    Ok(())
-}
-
-#[test]
-fn endereco_manual() -> Result<(), String> {
-    let xml = "<enderEmit>
-        <xLgr>Rua dos Testes</xLgr>
-        <nro>1020</nro>
-        <xCpl>0</xCpl>
-        <xBairro>Centro</xBairro>
-        <cMun>4319901</cMun>
-        <xMun>SAPIRANGA</xMun>
-        <UF>RS</UF>
-        <CEP>93800000</CEP>
-        <cPais>1058</cPais>
-        <xPais>BRASIL</xPais>
-        <fone>5190909090</fone>
-    </enderEmit>";
-
-    let endereco = xml.parse::<Endereco>()?;
-    assert_eq!("Rua dos Testes", endereco.logradouro);
-    assert_eq!("1020", endereco.numero);
-    assert_eq!(Some("0".to_string()), endereco.complemento);
-    assert_eq!("Centro", endereco.bairro);
-    assert_eq!(4319901, endereco.codigo_municipio);
-    assert_eq!("SAPIRANGA", endereco.nome_municipio);
-    assert_eq!("RS", endereco.sigla_uf);
-    assert_eq!(93800000, endereco.cep);
-    assert_eq!(Some("5190909090".to_string()), endereco.telefone);
 
     Ok(())
 }

--- a/nfe/src/tests/endereco.rs
+++ b/nfe/src/tests/endereco.rs
@@ -3,7 +3,7 @@
 use crate::*;
 
 #[test]
-fn emitente() -> Result<(), String> {
+fn emitente() -> Result<(), Error> {
     let xml = "<enderEmit>
         <xLgr>Rua dos Testes</xLgr>
         <nro>1020</nro>
@@ -33,7 +33,7 @@ fn emitente() -> Result<(), String> {
 }
 
 #[test]
-fn destinatario() -> Result<(), String> {
+fn destinatario() -> Result<(), Error> {
     let xml = "<enderDest>
         <xLgr>Av. Teste</xLgr>
         <nro>2040</nro>

--- a/nfe/src/tests/ide.rs
+++ b/nfe/src/tests/ide.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[test]
 fn from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let ide = Nfe::try_from(f)?.ide;
+    let ide = Nfe::try_from(f).map_err(|e| e.to_string())?.ide;
 
     assert_eq!(43, ide.codigo_uf);
     assert_eq!(4307609, ide.codigo_municipio);
@@ -25,7 +25,7 @@ fn from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn manual() -> Result<(), String> {
+fn manual() -> Result<(), Error> {
     let ide = XML_MANUAL.parse::<Identificacao>()?;
 
     assert_eq!(43, ide.codigo_uf);
@@ -44,7 +44,7 @@ fn manual() -> Result<(), String> {
 #[test]
 fn emissao_from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let emissao = Nfe::try_from(f)?.ide.emissao;
+    let emissao = Nfe::try_from(f).map_err(|e| e.to_string())?.ide.emissao;
 
     assert_eq!(Utc.ymd(2018, 09, 25).and_hms(3, 0, 0), emissao.horario);
     assert_eq!(TipoEmissao::Normal, emissao.tipo);
@@ -59,7 +59,7 @@ fn emissao_from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn emissao_manual() -> Result<(), String> {
+fn emissao_manual() -> Result<(), Error> {
     let emissao = XML_MANUAL.parse::<Emissao>()?;
 
     assert_eq!(Utc.ymd(2018, 09, 25).and_hms(3, 0, 0), emissao.horario);
@@ -77,7 +77,7 @@ fn emissao_manual() -> Result<(), String> {
 #[test]
 fn operacao_from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let operacao = Nfe::try_from(f)?.ide.operacao;
+    let operacao = Nfe::try_from(f).map_err(|e| e.to_string())?.ide.operacao;
 
     assert_eq!("Venda de producao do estabelecimento", operacao.natureza);
     assert_eq!(
@@ -94,7 +94,7 @@ fn operacao_from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn operacao_manual() -> Result<(), String> {
+fn operacao_manual() -> Result<(), Error> {
     let operacao = XML_MANUAL.parse::<Operacao>()?;
 
     assert_eq!("Venda de producao do estabelecimento", operacao.natureza);

--- a/nfe/src/tests/infnfe.rs
+++ b/nfe/src/tests/infnfe.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[test]
 fn nfe() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let nfe = Nfe::try_from(f)?;
+    let nfe = Nfe::try_from(f).map_err(|e| e.to_string())?;
 
     assert_eq!(
         "43180906929383000163550010000000261000010301",
@@ -24,7 +24,7 @@ fn nfe() -> Result<(), String> {
 #[test]
 fn informacao_complementar_from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
-    let nfe = NfeBase::try_from(f)?;
+    let nfe = NfeBase::try_from(f).map_err(|e| e.to_string())?;
 
     assert_eq!(
         Some("11899318;422-JERK DIONNY;CLIENTE RECUSOU INFORMAR CPF/CNPJ NO CUPOM".to_string()),

--- a/nfe/src/tests/itens.rs
+++ b/nfe/src/tests/itens.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[test]
 fn from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let itens = Nfe::try_from(f)?.itens;
+    let itens = Nfe::try_from(f).map_err(|e| e.to_string())?.itens;
 
     assert_eq!(1, itens.len());
 
@@ -21,7 +21,7 @@ fn from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn manual() -> Result<(), String> {
+fn manual() -> Result<(), Error> {
     let xml = "
         <det nItem=\"1\">
             <prod>
@@ -57,7 +57,7 @@ fn manual() -> Result<(), String> {
 #[test]
 fn produto_from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let itens = Nfe::try_from(f)?.itens;
+    let itens = Nfe::try_from(f).map_err(|e| e.to_string())?.itens;
 
     assert_eq!(1, itens.len());
 
@@ -91,7 +91,7 @@ fn produto_from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn produto_manual() -> Result<(), String> {
+fn produto_manual() -> Result<(), Error> {
     let xml = "
         <prod>
             <cProd>11007</cProd>
@@ -144,7 +144,7 @@ fn produto_manual() -> Result<(), String> {
 #[test]
 fn produtos() -> Result<(), String> {
     let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
-    let itens = NfeBase::try_from(f)?.itens;
+    let itens = NfeBase::try_from(f).map_err(|e| e.to_string())?.itens;
 
     assert_eq!(2, itens.len());
 
@@ -209,7 +209,7 @@ fn produtos() -> Result<(), String> {
 #[test]
 fn imposto_from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let itens = Nfe::try_from(f)?.itens;
+    let itens = Nfe::try_from(f).map_err(|e| e.to_string())?.itens;
 
     assert_eq!(1, itens.len());
 
@@ -248,7 +248,7 @@ fn imposto_from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn imposto_manual() -> Result<(), String> {
+fn imposto_manual() -> Result<(), Error> {
     let xml = "
         <imposto>
             <vTotTrib>0.00</vTotTrib>
@@ -318,7 +318,7 @@ fn imposto_manual() -> Result<(), String> {
 #[test]
 fn impostos() -> Result<(), String> {
     let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
-    let itens = NfeBase::try_from(f)?.itens;
+    let itens = NfeBase::try_from(f).map_err(|e| e.to_string())?.itens;
 
     assert_eq!(2, itens.len());
 

--- a/nfe/src/tests/parse.rs
+++ b/nfe/src/tests/parse.rs
@@ -15,9 +15,9 @@ fn nfe_from_str() -> Result<(), String> {
     let mut xml = String::new();
     f.read_to_string(&mut xml).map_err(|e| e.to_string())?;
 
-    Nfe::from_str(&xml)?;
+    Nfe::from_str(&xml).map_err(|e| e.to_string())?;
 
-    xml.parse::<Nfe>()?;
+    xml.parse::<Nfe>().map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -26,7 +26,7 @@ fn nfe_from_str() -> Result<(), String> {
 fn nfe_from_read() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
 
-    Nfe::try_from(f)?;
+    Nfe::try_from(f).map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -38,9 +38,9 @@ fn nfce_from_str() -> Result<(), String> {
     let mut xml = String::new();
     f.read_to_string(&mut xml).map_err(|e| e.to_string())?;
 
-    NfeBase::from_str(&xml)?;
+    NfeBase::from_str(&xml).map_err(|e| e.to_string())?;
 
-    xml.parse::<NfeBase>()?;
+    xml.parse::<NfeBase>().map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -49,7 +49,7 @@ fn nfce_from_str() -> Result<(), String> {
 fn nfce_from_read() -> Result<(), String> {
     let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
 
-    NfeBase::try_from(f)?;
+    NfeBase::try_from(f).map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/nfe/src/tests/totais.rs
+++ b/nfe/src/tests/totais.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[test]
 fn apenas_valores_dos_produtos() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let totais = Nfe::try_from(f)?.totais;
+    let totais = Nfe::try_from(f).map_err(|e| e.to_string())?.totais;
 
     assert_eq!(0.0, totais.valor_base_calculo);
     assert_eq!(0.0, totais.valor_icms);
@@ -29,7 +29,7 @@ fn apenas_valores_dos_produtos() -> Result<(), String> {
 #[test]
 fn produtos_com_pis_cofins() -> Result<(), String> {
     let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
-    let totais = NfeBase::try_from(f)?.totais;
+    let totais = NfeBase::try_from(f).map_err(|e| e.to_string())?.totais;
 
     assert_eq!(0.0, totais.valor_base_calculo);
     assert_eq!(0.0, totais.valor_icms);
@@ -47,7 +47,7 @@ fn produtos_com_pis_cofins() -> Result<(), String> {
 }
 
 #[test]
-fn manual_produtos_com_pis_cofins() -> Result<(), String> {
+fn manual_produtos_com_pis_cofins() -> Result<(), Error> {
     let xml = "<total>
             <ICMSTot>
                 <vBC>0.00</vBC>

--- a/nfe/src/tests/transporte.rs
+++ b/nfe/src/tests/transporte.rs
@@ -8,7 +8,7 @@ use crate::*;
 #[test]
 fn from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
-    let transporte = Nfe::try_from(f)?.transporte;
+    let transporte = Nfe::try_from(f).map_err(|e| e.to_string())?.transporte;
 
     assert_eq!(ModalidadeFrete::SemTransporte, transporte.modalidade);
 
@@ -16,7 +16,7 @@ fn from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn manual() -> Result<(), String> {
+fn manual() -> Result<(), Error> {
     let xml = "<transp><modFrete>9</modFrete></transp>";
 
     let transporte = xml.parse::<Transporte>()?;


### PR DESCRIPTION
Criadas as estruturas para comportarem os tipos de erros que a crate
pode gerar durante o parse.

Para o usuário final, a crate fornece o tipo Error do modelo 55. Por
meio dela, ou fazendo o parse da 'nfe base', o usuário consegue chegar
ao tipo que lida com os erros do serde e IO.