### PR TITLE
Serialize

### DIFF
--- a/nfe/Cargo.toml
+++ b/nfe/Cargo.toml
@@ -16,5 +16,5 @@ readme = "README.md"
 chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_repr = "0.1"
-serde-xml-rs = "0.4.1"
+quick-xml = { version = "0.22", features = [ "serialize" ] }
 derive_more = "0.99.16"

--- a/nfe/Cargo.toml
+++ b/nfe/Cargo.toml
@@ -16,5 +16,8 @@ readme = "README.md"
 chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_repr = "0.1"
-quick-xml = { version = "0.22", features = [ "serialize" ] }
 derive_more = "0.99.16"
+
+[dependencies.quick-xml]
+version = "0.23.0-alpha3"
+features = ["serialize"]

--- a/nfe/src/base/dest.rs
+++ b/nfe/src/base/dest.rs
@@ -13,7 +13,9 @@ pub struct Destinatario {
     #[serde(rename = "CNPJ")]
     pub cnpj: String,
     #[serde(rename = "xNome")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub razao_social: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "enderDest")]
     pub endereco: Option<Endereco>,
     #[serde(rename = "IE")]

--- a/nfe/src/base/dest.rs
+++ b/nfe/src/base/dest.rs
@@ -1,4 +1,4 @@
-//! Destinarário da NF-e
+//! Destinatário da NF-e
 
 use super::endereco::*;
 use super::Error;
@@ -7,7 +7,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 /// Destinatário base da NF-e
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, Clone)]
 #[serde(rename = "dest")]
 pub struct Destinatario {
     #[serde(rename = "$unflatten=CNPJ")]

--- a/nfe/src/base/dest.rs
+++ b/nfe/src/base/dest.rs
@@ -10,17 +10,17 @@ use std::str::FromStr;
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename = "dest")]
 pub struct Destinatario {
-    #[serde(rename = "CNPJ")]
+    #[serde(rename = "$unflatten=CNPJ")]
     pub cnpj: String,
-    #[serde(rename = "xNome")]
+    #[serde(rename = "$unflatten=xNome")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub razao_social: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "enderDest")]
     pub endereco: Option<Endereco>,
-    #[serde(rename = "IE")]
+    #[serde(rename = "$unflatten=IE")]
     pub ie: Option<String>,
-    #[serde(rename = "indIEDest")]
+    #[serde(rename = "$unflatten=indIEDest")]
     pub indicador_ie: IndicadorContribuicaoIe,
 }
 
@@ -46,6 +46,6 @@ impl FromStr for Destinatario {
 
 impl ToString for Destinatario {
     fn to_string(&self) -> String {
-        serde_xml_rs::to_string(self).expect("Falha ao serializar o destinatário")
+        quick_xml::se::to_string(self).expect("Falha ao serializar o destinatário")
     }
 }

--- a/nfe/src/base/dest.rs
+++ b/nfe/src/base/dest.rs
@@ -2,12 +2,13 @@
 
 use super::endereco::*;
 use super::Error;
-use serde::Deserialize;
-use serde_repr::Deserialize_repr;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 /// Destinatário base da NF-e
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename = "dest")]
 pub struct Destinatario {
     #[serde(rename = "CNPJ")]
     pub cnpj: String,
@@ -22,7 +23,7 @@ pub struct Destinatario {
 }
 
 /// Indicador da IE do destinatário
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum IndicadorContribuicaoIe {
     /// Contribuinte ICMS
@@ -38,5 +39,11 @@ impl FromStr for Destinatario {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         quick_xml::de::from_str(s).map_err(|e| e.into())
+    }
+}
+
+impl ToString for Destinatario {
+    fn to_string(&self) -> String {
+        serde_xml_rs::to_string(self).expect("Falha ao serializar o destinatário")
     }
 }

--- a/nfe/src/base/dest.rs
+++ b/nfe/src/base/dest.rs
@@ -37,6 +37,6 @@ impl FromStr for Destinatario {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/emit.rs
+++ b/nfe/src/base/emit.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Emitente da NF-e
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, Clone)]
 #[serde(rename = "emit")]
 pub struct Emitente {
     #[serde(rename = "$unflatten=CNPJ")]

--- a/nfe/src/base/emit.rs
+++ b/nfe/src/base/emit.rs
@@ -9,16 +9,16 @@ use std::str::FromStr;
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename = "emit")]
 pub struct Emitente {
-    #[serde(rename = "CNPJ")]
+    #[serde(rename = "$unflatten=CNPJ")]
     pub cnpj: String,
-    #[serde(rename = "xNome")]
+    #[serde(rename = "$unflatten=xNome")]
     pub razao_social: String,
-    #[serde(rename = "xFant")]
+    #[serde(rename = "$unflatten=xFant")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nome_fantasia: Option<String>,
-    #[serde(rename = "IE")]
+    #[serde(rename = "$unflatten=IE")]
     pub ie: String,
-    #[serde(rename = "IEST")]
+    #[serde(rename = "$unflatten=IEST")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iest: Option<u32>,
     #[serde(rename = "enderEmit")]
@@ -35,6 +35,6 @@ impl FromStr for Emitente {
 
 impl ToString for Emitente {
     fn to_string(&self) -> String {
-        serde_xml_rs::to_string(self).expect("Falha ao serializar o emitente")
+        quick_xml::se::to_string(self).expect("Falha ao serializar o emitente")
     }
 }

--- a/nfe/src/base/emit.rs
+++ b/nfe/src/base/emit.rs
@@ -26,6 +26,6 @@ impl FromStr for Emitente {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/emit.rs
+++ b/nfe/src/base/emit.rs
@@ -2,21 +2,24 @@
 
 use super::endereco::*;
 use super::Error;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Emitente da NF-e
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename = "emit")]
 pub struct Emitente {
     #[serde(rename = "CNPJ")]
     pub cnpj: String,
     #[serde(rename = "xNome")]
     pub razao_social: String,
     #[serde(rename = "xFant")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nome_fantasia: Option<String>,
     #[serde(rename = "IE")]
     pub ie: String,
     #[serde(rename = "IEST")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub iest: Option<u32>,
     #[serde(rename = "enderEmit")]
     pub endereco: Endereco,
@@ -27,5 +30,11 @@ impl FromStr for Emitente {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         quick_xml::de::from_str(s).map_err(|e| e.into())
+    }
+}
+
+impl ToString for Emitente {
+    fn to_string(&self) -> String {
+        serde_xml_rs::to_string(self).expect("Falha ao serializar o emitente")
     }
 }

--- a/nfe/src/base/endereco.rs
+++ b/nfe/src/base/endereco.rs
@@ -31,6 +31,6 @@ impl FromStr for Endereco {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/endereco.rs
+++ b/nfe/src/base/endereco.rs
@@ -1,11 +1,11 @@
 //! Endereço do emitente/destinatário da NF-e
 
 use super::Error;
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use std::str::FromStr;
 
 /// Representação de um endereço usado na NFe
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct Endereco {
     #[serde(rename = "xLgr")]
     pub logradouro: String,
@@ -22,7 +22,7 @@ pub struct Endereco {
     #[serde(rename = "UF")]
     pub sigla_uf: String,
     #[serde(rename = "CEP")]
-    pub cep: u32,
+    pub cep: String,
     #[serde(rename = "cPais")]
     pub codigo_pais: u32,
     #[serde(rename = "xPais")]
@@ -36,6 +36,31 @@ impl FromStr for Endereco {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         quick_xml::de::from_str(s).map_err(|e| e.into())
+    }
+}
+
+impl Serialize for Endereco {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(11))?;
+        map.serialize_entry("xLgr", &self.logradouro)?;
+        map.serialize_entry("nro", &self.numero)?;
+        if let Some(cpl) = &self.complemento {
+            map.serialize_entry("xCpl", cpl)?;
+        }
+        map.serialize_entry("xBairro", &self.bairro)?;
+        map.serialize_entry("cMun", &self.codigo_municipio)?;
+        map.serialize_entry("xMun", &self.nome_municipio)?;
+        map.serialize_entry("UF", &self.sigla_uf)?;
+        map.serialize_entry("CEP", &self.cep)?;
+        map.serialize_entry("cPais", &self.codigo_pais)?;
+        map.serialize_entry("xPais", &self.nome_pais)?;
+        if let Some(fone) = &self.telefone {
+            map.serialize_entry("fone", fone)?;
+        }
+        map.end()
     }
 }
 

--- a/nfe/src/base/endereco.rs
+++ b/nfe/src/base/endereco.rs
@@ -1,33 +1,35 @@
 //! Endereço do emitente/destinatário da NF-e
 
 use super::Error;
-use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Representação de um endereço usado na NFe
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Serialize)]
 pub struct Endereco {
-    #[serde(rename = "xLgr")]
+    #[serde(rename = "$unflatten=xLgr")]
     pub logradouro: String,
-    #[serde(rename = "nro")]
+    #[serde(rename = "$unflatten=nro")]
     pub numero: String,
-    #[serde(rename = "xCpl")]
+    #[serde(rename = "$unflatten=xCpl")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub complemento: Option<String>,
-    #[serde(rename = "xBairro")]
+    #[serde(rename = "$unflatten=xBairro")]
     pub bairro: String,
-    #[serde(rename = "cMun")]
+    #[serde(rename = "$unflatten=cMun")]
     pub codigo_municipio: u32,
-    #[serde(rename = "xMun")]
+    #[serde(rename = "$unflatten=xMun")]
     pub nome_municipio: String,
-    #[serde(rename = "UF")]
+    #[serde(rename = "$unflatten=UF")]
     pub sigla_uf: String,
-    #[serde(rename = "CEP")]
+    #[serde(rename = "$unflatten=CEP")]
     pub cep: String,
-    #[serde(rename = "cPais")]
+    #[serde(rename = "$unflatten=cPais")]
     pub codigo_pais: u32,
-    #[serde(rename = "xPais")]
+    #[serde(rename = "$unflatten=xPais")]
     pub nome_pais: String,
-    #[serde(rename = "fone")]
+    #[serde(rename = "$unflatten=fone")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub telefone: Option<String>,
 }
 
@@ -39,33 +41,8 @@ impl FromStr for Endereco {
     }
 }
 
-impl Serialize for Endereco {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(11))?;
-        map.serialize_entry("xLgr", &self.logradouro)?;
-        map.serialize_entry("nro", &self.numero)?;
-        if let Some(cpl) = &self.complemento {
-            map.serialize_entry("xCpl", cpl)?;
-        }
-        map.serialize_entry("xBairro", &self.bairro)?;
-        map.serialize_entry("cMun", &self.codigo_municipio)?;
-        map.serialize_entry("xMun", &self.nome_municipio)?;
-        map.serialize_entry("UF", &self.sigla_uf)?;
-        map.serialize_entry("CEP", &self.cep)?;
-        map.serialize_entry("cPais", &self.codigo_pais)?;
-        map.serialize_entry("xPais", &self.nome_pais)?;
-        if let Some(fone) = &self.telefone {
-            map.serialize_entry("fone", fone)?;
-        }
-        map.end()
-    }
-}
-
 impl ToString for Endereco {
     fn to_string(&self) -> String {
-        serde_xml_rs::to_string(self).expect("Falha ao serializar o endereço")
+        quick_xml::se::to_string(self).expect("Falha ao serializar o endereço")
     }
 }

--- a/nfe/src/base/endereco.rs
+++ b/nfe/src/base/endereco.rs
@@ -1,11 +1,11 @@
 //! Endereço do emitente/destinatário da NF-e
 
 use super::Error;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Representação de um endereço usado na NFe
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Endereco {
     #[serde(rename = "xLgr")]
     pub logradouro: String,
@@ -23,6 +23,10 @@ pub struct Endereco {
     pub sigla_uf: String,
     #[serde(rename = "CEP")]
     pub cep: u32,
+    #[serde(rename = "cPais")]
+    pub codigo_pais: u32,
+    #[serde(rename = "xPais")]
+    pub nome_pais: String,
     #[serde(rename = "fone")]
     pub telefone: Option<String>,
 }
@@ -32,5 +36,11 @@ impl FromStr for Endereco {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         quick_xml::de::from_str(s).map_err(|e| e.into())
+    }
+}
+
+impl ToString for Endereco {
+    fn to_string(&self) -> String {
+        serde_xml_rs::to_string(self).expect("Falha ao serializar o endereço")
     }
 }

--- a/nfe/src/base/error.rs
+++ b/nfe/src/base/error.rs
@@ -7,5 +7,5 @@ pub enum Error {
     #[display(fmt = "Falha na leitura do arquivo: {}", _0)]
     Io(std::io::Error),
     #[display(fmt = "Falha no parse: {}", _0)]
-    Serde(serde_xml_rs::Error),
+    Serde(quick_xml::de::DeError),
 }

--- a/nfe/src/base/ide/emissao.rs
+++ b/nfe/src/base/ide/emissao.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Dados referentes a emissão da nota
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Emissao {
     pub horario: DateTime<Utc>,
     pub tipo: TipoEmissao,

--- a/nfe/src/base/ide/emissao.rs
+++ b/nfe/src/base/ide/emissao.rs
@@ -71,6 +71,6 @@ impl FromStr for Emissao {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/ide/emissao.rs
+++ b/nfe/src/base/ide/emissao.rs
@@ -1,28 +1,20 @@
 //! Dados da emissão da NF-e
 
-use super::Error;
 use chrono::prelude::*;
-use serde::Deserialize;
-use serde_repr::Deserialize_repr;
-use std::str::FromStr;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Dados referentes a emissão da nota
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Emissao {
-    #[serde(rename = "dhEmi")]
     pub horario: DateTime<Utc>,
-    #[serde(rename = "tpEmis")]
     pub tipo: TipoEmissao,
-    #[serde(rename = "finNFe")]
     pub finalidade: FinalidadeEmissao,
-    #[serde(rename = "procEmi")]
     pub processo: TipoProcessoEmissao,
-    #[serde(rename = "verProc")]
     pub versao_processo: String,
 }
 
 /// Tipo da emissão da nota
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoEmissao {
     /// Emissão normal (não em contingência)
@@ -44,7 +36,7 @@ pub enum TipoEmissao {
 }
 
 /// Finalidade da emissão da nota
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum FinalidadeEmissao {
     Normal = 1,
@@ -54,7 +46,7 @@ pub enum FinalidadeEmissao {
 }
 
 /// Tipo do processo de emissão
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoProcessoEmissao {
     /// Emissão de NF-e com aplicativo do contribuinte
@@ -65,12 +57,4 @@ pub enum TipoProcessoEmissao {
     AvulsaPeloContribuinte = 2,
     /// Emissão NF-e pelo contribuinte com aplicativo fornecido pelo Fisco
     ViaAplicativoDoFisco = 3,
-}
-
-impl FromStr for Emissao {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        quick_xml::de::from_str(s).map_err(|e| e.into())
-    }
 }

--- a/nfe/src/base/ide/mod.rs
+++ b/nfe/src/base/ide/mod.rs
@@ -13,7 +13,7 @@ pub use emissao::*;
 pub use operacao::*;
 
 /// Identificação da NF-e
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Identificacao {
     pub codigo_uf: u8,
     pub chave: ComposicaoChaveAcesso,
@@ -56,7 +56,7 @@ pub enum TipoAmbiente {
 }
 
 /// Dados referentes a regeração da chave de acesso
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ComposicaoChaveAcesso {
     pub codigo: String,
     pub digito_verificador: u8,

--- a/nfe/src/base/ide/mod.rs
+++ b/nfe/src/base/ide/mod.rs
@@ -66,7 +66,7 @@ impl FromStr for Identificacao {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/ide/mod.rs
+++ b/nfe/src/base/ide/mod.rs
@@ -2,8 +2,8 @@
 
 use super::Error;
 use chrono::prelude::*;
-use serde::{Deserialize, Deserializer};
-use serde_repr::Deserialize_repr;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 mod emissao;
@@ -28,7 +28,7 @@ pub struct Identificacao {
 }
 
 /// Modelo do documento fiscal: NF-e ou NFC-e
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum ModeloDocumentoFiscal {
     Nfe = 55,
@@ -36,7 +36,7 @@ pub enum ModeloDocumentoFiscal {
 }
 
 /// Formato de impressão do DANFE
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum FormatoImpressaoDanfe {
     SemGeracao = 0,
@@ -48,7 +48,7 @@ pub enum FormatoImpressaoDanfe {
 }
 
 /// Tipo do ambiente da NF
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoAmbiente {
     Producao = 1,
@@ -56,9 +56,9 @@ pub enum TipoAmbiente {
 }
 
 /// Dados referentes a regeração da chave de acesso
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ComposicaoChaveAcesso {
-    pub codigo: u32,
+    pub codigo: String,
     pub digito_verificador: u8,
 }
 
@@ -70,61 +70,18 @@ impl FromStr for Identificacao {
     }
 }
 
+impl ToString for Identificacao {
+    fn to_string(&self) -> String {
+        quick_xml::se::to_string(self).expect("Falha ao serializar a identificação")
+    }
+}
+
 impl<'de> Deserialize<'de> for Identificacao {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         // TODO: voltar a tentar usar o serde flatten
-
-        #[derive(Deserialize)]
-        struct IdeContainer {
-            #[serde(rename = "cUF")]
-            pub codigo_uf: u8,
-            #[serde(rename = "nNF")]
-            pub numero: u32,
-            #[serde(rename = "serie")]
-            pub serie: u16,
-            #[serde(rename = "mod")]
-            pub modelo: ModeloDocumentoFiscal,
-            #[serde(rename = "cMunFG")]
-            pub codigo_municipio: u32,
-            #[serde(rename = "tpImp")]
-            pub formato_danfe: FormatoImpressaoDanfe,
-            #[serde(rename = "tpAmb")]
-            pub ambiente: TipoAmbiente,
-
-            #[serde(rename = "cNF")]
-            pub c_codigo: u32,
-            #[serde(rename = "cDV")]
-            pub c_digito_verificador: u8,
-
-            #[serde(rename = "dhEmi")]
-            pub e_horario: DateTime<Utc>,
-            #[serde(rename = "tpEmis")]
-            pub e_tipo: TipoEmissao,
-            #[serde(rename = "finNFe")]
-            pub e_finalidade: FinalidadeEmissao,
-            #[serde(rename = "procEmi")]
-            pub e_processo: TipoProcessoEmissao,
-            #[serde(rename = "verProc")]
-            pub e_versao_processo: String,
-
-            #[serde(rename = "dhSaiEnt")]
-            pub o_horario: Option<DateTime<Utc>>,
-            #[serde(rename = "tpNF")]
-            pub o_tipo: TipoOperacao,
-            #[serde(rename = "idDest")]
-            pub o_destino: DestinoOperacao,
-            #[serde(rename = "natOp")]
-            pub o_natureza: String,
-            #[serde(rename = "indFinal")]
-            pub o_consumidor: TipoConsumidor,
-            #[serde(rename = "indPres")]
-            pub o_presenca: TipoPresencaComprador,
-            #[serde(rename = "indIntermed")]
-            pub o_intermediador: Option<TipoIntermediador>,
-        }
 
         let ide = IdeContainer::deserialize(deserializer)?;
 
@@ -137,7 +94,7 @@ impl<'de> Deserialize<'de> for Identificacao {
             formato_danfe: ide.formato_danfe,
             ambiente: ide.ambiente,
             chave: ComposicaoChaveAcesso {
-                codigo: ide.c_codigo,
+                codigo: ide.c_codigo.clone(),
                 digito_verificador: ide.c_digito_verificador,
             },
             operacao: Operacao {
@@ -158,4 +115,105 @@ impl<'de> Deserialize<'de> for Identificacao {
             },
         })
     }
+}
+
+impl Serialize for Identificacao {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let ide = IdeContainer {
+            codigo_uf: self.codigo_uf,
+            numero: self.numero,
+            serie: self.serie,
+            modelo: self.modelo,
+            codigo_municipio: self.codigo_municipio,
+            formato_danfe: self.formato_danfe,
+            ambiente: self.ambiente,
+            c_codigo: self.chave.codigo.clone(),
+            c_digito_verificador: self.chave.digito_verificador,
+            o_horario: self.operacao.horario,
+            o_tipo: self.operacao.tipo,
+            o_destino: self.operacao.destino,
+            o_natureza: self.operacao.natureza.clone(),
+            o_consumidor: self.operacao.consumidor,
+            o_presenca: self.operacao.presenca,
+            o_intermediador: self.operacao.intermediador,
+            e_horario: self.emissao.horario,
+            e_tipo: self.emissao.tipo,
+            e_finalidade: self.emissao.finalidade,
+            e_processo: self.emissao.processo,
+            e_versao_processo: self.emissao.versao_processo.clone(),
+        };
+
+        ide.serialize(serializer)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename = "ide")]
+struct IdeContainer {
+    #[serde(rename = "$unflatten=cUF")]
+    pub codigo_uf: u8,
+    #[serde(rename = "$unflatten=nNF")]
+    pub numero: u32,
+    #[serde(rename = "$unflatten=serie")]
+    pub serie: u16,
+    #[serde(rename = "$unflatten=mod")]
+    pub modelo: ModeloDocumentoFiscal,
+    #[serde(rename = "$unflatten=cMunFG")]
+    pub codigo_municipio: u32,
+    #[serde(rename = "$unflatten=tpImp")]
+    pub formato_danfe: FormatoImpressaoDanfe,
+    #[serde(rename = "$unflatten=tpAmb")]
+    pub ambiente: TipoAmbiente,
+
+    #[serde(rename = "$unflatten=cNF")]
+    pub c_codigo: String,
+    #[serde(rename = "$unflatten=cDV")]
+    pub c_digito_verificador: u8,
+
+    #[serde(rename = "$unflatten=dhEmi")]
+    #[serde(serialize_with = "serialize_horario")]
+    pub e_horario: DateTime<Utc>,
+    #[serde(rename = "$unflatten=tpEmis")]
+    pub e_tipo: TipoEmissao,
+    #[serde(rename = "$unflatten=finNFe")]
+    pub e_finalidade: FinalidadeEmissao,
+    #[serde(rename = "$unflatten=procEmi")]
+    pub e_processo: TipoProcessoEmissao,
+    #[serde(rename = "$unflatten=verProc")]
+    pub e_versao_processo: String,
+
+    #[serde(rename = "$unflatten=dhSaiEnt")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(serialize_with = "serialize_horario_op")]
+    pub o_horario: Option<DateTime<Utc>>,
+    #[serde(rename = "$unflatten=tpNF")]
+    pub o_tipo: TipoOperacao,
+    #[serde(rename = "$unflatten=idDest")]
+    pub o_destino: DestinoOperacao,
+    #[serde(rename = "$unflatten=natOp")]
+    pub o_natureza: String,
+    #[serde(rename = "$unflatten=indFinal")]
+    pub o_consumidor: TipoConsumidor,
+    #[serde(rename = "$unflatten=indPres")]
+    pub o_presenca: TipoPresencaComprador,
+    #[serde(rename = "$unflatten=indIntermed")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub o_intermediador: Option<TipoIntermediador>,
+}
+
+fn serialize_horario<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&date.to_rfc3339())
+}
+
+fn serialize_horario_op<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serialize_horario(&date.unwrap(), serializer)
 }

--- a/nfe/src/base/ide/operacao.rs
+++ b/nfe/src/base/ide/operacao.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Dados referentes a operação da nota
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Operacao {
     pub horario: Option<DateTime<Utc>>,
     pub tipo: TipoOperacao,

--- a/nfe/src/base/ide/operacao.rs
+++ b/nfe/src/base/ide/operacao.rs
@@ -84,6 +84,6 @@ impl FromStr for Operacao {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/ide/operacao.rs
+++ b/nfe/src/base/ide/operacao.rs
@@ -1,32 +1,22 @@
 //! Dados da operação da NF-e
 
-use super::Error;
 use chrono::prelude::*;
-use serde::Deserialize;
-use serde_repr::Deserialize_repr;
-use std::str::FromStr;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Dados referentes a operação da nota
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Operacao {
-    #[serde(rename = "dhSaiEnt")]
     pub horario: Option<DateTime<Utc>>,
-    #[serde(rename = "tpNF")]
     pub tipo: TipoOperacao,
-    #[serde(rename = "idDest")]
     pub destino: DestinoOperacao,
-    #[serde(rename = "natOp")]
     pub natureza: String,
-    #[serde(rename = "indFinal")]
     pub consumidor: TipoConsumidor,
-    #[serde(rename = "indPres")]
     pub presenca: TipoPresencaComprador,
-    #[serde(rename = "indIntermed")]
     pub intermediador: Option<TipoIntermediador>,
 }
 
 /// Tipo de operação da nota
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoOperacao {
     Entrada = 0,
@@ -34,7 +24,7 @@ pub enum TipoOperacao {
 }
 
 /// Destino da operação da nota
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum DestinoOperacao {
     Interna = 1,
@@ -43,7 +33,7 @@ pub enum DestinoOperacao {
 }
 
 /// Tipo do consumidor da NF-e
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoConsumidor {
     Normal = 0,
@@ -51,7 +41,7 @@ pub enum TipoConsumidor {
 }
 
 /// Tipo da presença do comprador
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoPresencaComprador {
     /// Não se aplica. Ex.: Nota complementar ou de ajuste
@@ -71,19 +61,11 @@ pub enum TipoPresencaComprador {
 }
 
 /// Tipo do intermediador
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum TipoIntermediador {
     /// Operação sem intermediador (em site ou plataforma própria)
     SemIntermediador = 0,
     /// Operação em site ou plataforma de terceiros (intermediadores/marketplace)
     EmSiteDeTerceiros = 1,
-}
-
-impl FromStr for Operacao {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        quick_xml::de::from_str(s).map_err(|e| e.into())
-    }
 }

--- a/nfe/src/base/item/imposto/cofins.rs
+++ b/nfe/src/base/item/imposto/cofins.rs
@@ -17,7 +17,6 @@ impl<'de> Deserialize<'de> for GrupoCofins {
     where
         D: Deserializer<'de>,
     {
-
         #[derive(Deserialize)]
         pub enum TipoCofins {
             #[serde(rename = "COFINSOutr")]
@@ -29,9 +28,9 @@ impl<'de> Deserialize<'de> for GrupoCofins {
         }
 
         #[derive(Deserialize)]
-        struct GrupoCofinsContainer{
+        struct GrupoCofinsContainer {
             #[serde(rename = "$value")]
-            inner: TipoCofins
+            inner: TipoCofins,
         }
 
         let gr = GrupoCofinsContainer::deserialize(deserializer)?;
@@ -39,7 +38,7 @@ impl<'de> Deserialize<'de> for GrupoCofins {
         Ok(match gr.inner {
             TipoCofins::CofinsOutr(g) => GrupoCofins::CofinsOutr(g),
             TipoCofins::CofinsNt(g) => GrupoCofins::CofinsNt(g),
-            TipoCofins::CofinsAliq(g) => GrupoCofins::CofinsAliq(g)
+            TipoCofins::CofinsAliq(g) => GrupoCofins::CofinsAliq(g),
         })
     }
 }

--- a/nfe/src/base/item/imposto/cofins.rs
+++ b/nfe/src/base/item/imposto/cofins.rs
@@ -2,7 +2,7 @@
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 /// COFINS
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum GrupoCofins {
     /// Outras Operações
     CofinsOutr(GrupoCofinsOutr),
@@ -76,7 +76,7 @@ struct GrupoCofinsContainer {
 }
 
 /// Grupo COFINS Outr - Outras Operações
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoCofinsOutr {
     /// CST - Código de Situação Tributária do COFINS
     #[serde(rename = "$unflatten=CST")]
@@ -89,34 +89,16 @@ pub struct GrupoCofinsOutr {
     pub aliquota: f32,
 }
 
-impl Clone for GrupoCofinsOutr {
-    fn clone(&self) -> Self {
-        Self {
-            codigo_situacao: self.codigo_situacao.clone(),
-            valor_base_calculo: self.valor_base_calculo,
-            aliquota: self.aliquota,
-        }
-    }
-}
-
 /// Grupo COFINS NT - COFINS não tributado
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoCofinsNt {
     /// CST - Código de Situação Tributária do COFINS
     #[serde(rename = "$unflatten=CST")]
     pub codigo_situacao: String,
 }
 
-impl Clone for GrupoCofinsNt {
-    fn clone(&self) -> Self {
-        Self {
-            codigo_situacao: self.codigo_situacao.clone(),
-        }
-    }
-}
-
 /// Grupo COFINS Aliq - Aliq Operações
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoCofinsAliq {
     /// CST - Código de Situação Tributária do COFINS
     #[serde(rename = "$unflatten=CST")]
@@ -130,15 +112,4 @@ pub struct GrupoCofinsAliq {
     /// Valor do COFINS
     #[serde(rename = "$unflatten=vCOFINS")]
     pub valor: f32,
-}
-
-impl Clone for GrupoCofinsAliq {
-    fn clone(&self) -> Self {
-        Self {
-            codigo_situacao: self.codigo_situacao.clone(),
-            valor_base_calculo: self.valor_base_calculo,
-            aliquota: self.aliquota,
-            valor: self.valor,
-        }
-    }
 }

--- a/nfe/src/base/item/imposto/cofins.rs
+++ b/nfe/src/base/item/imposto/cofins.rs
@@ -1,18 +1,47 @@
 /// Grupos de COFINS
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 /// COFINS
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq)]
 pub enum GrupoCofins {
     /// Outras Operações
-    #[serde(rename = "COFINSOutr")]
     CofinsOutr(GrupoCofinsOutr),
     /// Não Tributado
-    #[serde(rename = "COFINSNT")]
     CofinsNt(GrupoCofinsNt),
     /// Tributado pela alíquota
-    #[serde(rename = "COFINSAliq")]
     CofinsAliq(GrupoCofinsAliq),
+}
+
+impl<'de> Deserialize<'de> for GrupoCofins {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+
+        #[derive(Deserialize)]
+        pub enum TipoCofins {
+            #[serde(rename = "COFINSOutr")]
+            CofinsOutr(GrupoCofinsOutr),
+            #[serde(rename = "COFINSNT")]
+            CofinsNt(GrupoCofinsNt),
+            #[serde(rename = "COFINSAliq")]
+            CofinsAliq(GrupoCofinsAliq),
+        }
+
+        #[derive(Deserialize)]
+        struct GrupoCofinsContainer{
+            #[serde(rename = "$value")]
+            inner: TipoCofins
+        }
+
+        let gr = GrupoCofinsContainer::deserialize(deserializer)?;
+
+        Ok(match gr.inner {
+            TipoCofins::CofinsOutr(g) => GrupoCofins::CofinsOutr(g),
+            TipoCofins::CofinsNt(g) => GrupoCofins::CofinsNt(g),
+            TipoCofins::CofinsAliq(g) => GrupoCofins::CofinsAliq(g)
+        })
+    }
 }
 
 /// Grupo COFINS Outr - Outras Operações

--- a/nfe/src/base/item/imposto/icms.rs
+++ b/nfe/src/base/item/imposto/icms.rs
@@ -17,7 +17,6 @@ impl<'de> Deserialize<'de> for GrupoIcms {
     where
         D: Deserializer<'de>,
     {
-
         #[derive(Deserialize)]
         pub enum TipoIcms {
             #[serde(rename = "ICMSSN202")]
@@ -27,16 +26,16 @@ impl<'de> Deserialize<'de> for GrupoIcms {
         }
 
         #[derive(Deserialize)]
-        struct GrupoIcmsContainer{
+        struct GrupoIcmsContainer {
             #[serde(rename = "$value")]
-            inner: TipoIcms
+            inner: TipoIcms,
         }
 
         let gr = GrupoIcmsContainer::deserialize(deserializer)?;
 
         Ok(match gr.inner {
             TipoIcms::IcmsSn202(g) => GrupoIcms::IcmsSn202(g),
-            TipoIcms::Icms60(g) => GrupoIcms::Icms60(g)
+            TipoIcms::Icms60(g) => GrupoIcms::Icms60(g),
         })
     }
 }

--- a/nfe/src/base/item/imposto/icms.rs
+++ b/nfe/src/base/item/imposto/icms.rs
@@ -4,7 +4,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// ICMS
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum GrupoIcms {
     /// Tributação ICMS pelo Simples Nacional, CSOSN=202 ou 203
     IcmsSn202(GrupoIcmsSn202),
@@ -62,7 +62,7 @@ struct GrupoIcmsContainer {
 }
 
 /// Grupo ICMS 60 - Tributação ICMS cobrado anteriormente por substituição tributária
-#[derive(Debug, PartialEq, Deserialize, Serialize, Copy, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoIcms60 {
     /// Origem da mercadoria
     #[serde(rename = "$unflatten=orig")]
@@ -79,7 +79,7 @@ pub struct GrupoIcms60 {
 }
 
 /// Tributação ICMS pelo Simples Nacional, CSOSN=202 ou 203
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoIcmsSn202 {
     /// Origem da mercadoria
     #[serde(rename = "$unflatten=orig")]
@@ -99,19 +99,6 @@ pub struct GrupoIcmsSn202 {
     /// Valor do ICMS ST
     #[serde(rename = "$unflatten=vICMSST")]
     pub valor: f32,
-}
-
-impl Clone for GrupoIcmsSn202 {
-    fn clone(&self) -> Self {
-        Self {
-            origem: self.origem,
-            codigo_situacao: self.codigo_situacao.clone(),
-            base_calculo: self.base_calculo,
-            valor_base_calculo: self.valor_base_calculo,
-            aliquota: self.aliquota,
-            valor: self.valor,
-        }
-    }
 }
 
 /// Origem da mercadoria

--- a/nfe/src/base/item/imposto/mod.rs
+++ b/nfe/src/base/item/imposto/mod.rs
@@ -13,7 +13,7 @@ pub use icms::*;
 pub use pis::*;
 
 /// Detalhamentos impostos sobre o item
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, Clone)]
 #[serde(rename = "imposto")]
 pub struct Imposto {
     /// Valor aproximado total de tributos federais, estaduais e municipais

--- a/nfe/src/base/item/imposto/mod.rs
+++ b/nfe/src/base/item/imposto/mod.rs
@@ -33,6 +33,6 @@ impl FromStr for Imposto {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/item/imposto/mod.rs
+++ b/nfe/src/base/item/imposto/mod.rs
@@ -1,7 +1,7 @@
 //! Impostos dos itens
 
 use super::Error;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 mod cofins;
@@ -13,10 +13,11 @@ pub use icms::*;
 pub use pis::*;
 
 /// Detalhamentos impostos sobre o item
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename = "imposto")]
 pub struct Imposto {
     /// Valor aproximado total de tributos federais, estaduais e municipais
-    #[serde(rename = "vTotTrib")]
+    #[serde(rename = "$unflatten=vTotTrib")]
     pub valor_aproximado: Option<f32>,
     /// Informações do ICMS da Operação própria e ST
     #[serde(rename = "ICMS")]
@@ -34,5 +35,11 @@ impl FromStr for Imposto {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         quick_xml::de::from_str(s).map_err(|e| e.into())
+    }
+}
+
+impl ToString for Imposto {
+    fn to_string(&self) -> String {
+        quick_xml::se::to_string(self).expect("Falha ao serializar o imposto")
     }
 }

--- a/nfe/src/base/item/imposto/pis.rs
+++ b/nfe/src/base/item/imposto/pis.rs
@@ -17,7 +17,6 @@ impl<'de> Deserialize<'de> for GrupoPis {
     where
         D: Deserializer<'de>,
     {
-
         #[derive(Deserialize)]
         pub enum TipoPis {
             #[serde(rename = "PISOutr")]
@@ -29,9 +28,9 @@ impl<'de> Deserialize<'de> for GrupoPis {
         }
 
         #[derive(Deserialize)]
-        struct GrupoPisContainer{
+        struct GrupoPisContainer {
             #[serde(rename = "$value")]
-            inner: TipoPis
+            inner: TipoPis,
         }
 
         let gr = GrupoPisContainer::deserialize(deserializer)?;
@@ -39,7 +38,7 @@ impl<'de> Deserialize<'de> for GrupoPis {
         Ok(match gr.inner {
             TipoPis::PisOutr(g) => GrupoPis::PisOutr(g),
             TipoPis::PisNt(g) => GrupoPis::PisNt(g),
-            TipoPis::PisAliq(g) => GrupoPis::PisAliq(g)
+            TipoPis::PisAliq(g) => GrupoPis::PisAliq(g),
         })
     }
 }

--- a/nfe/src/base/item/imposto/pis.rs
+++ b/nfe/src/base/item/imposto/pis.rs
@@ -2,7 +2,7 @@
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 /// PIS
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum GrupoPis {
     /// Outras Operações
     PisOutr(GrupoPisOutr),
@@ -76,7 +76,7 @@ struct GrupoPisContainer {
 }
 
 /// Grupo PIS Outr - Outras Operações
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoPisOutr {
     /// CST - Código de Situação Tributária do PIS
     #[serde(rename = "$unflatten=CST")]
@@ -89,34 +89,16 @@ pub struct GrupoPisOutr {
     pub aliquota: f32,
 }
 
-impl Clone for GrupoPisOutr {
-    fn clone(&self) -> Self {
-        Self {
-            codigo_situacao: self.codigo_situacao.clone(),
-            valor_base_calculo: self.valor_base_calculo,
-            aliquota: self.aliquota,
-        }
-    }
-}
-
 /// Grupo PIS NT - PIS não tributado
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoPisNt {
     /// CST - Código de Situação Tributária do PIS
     #[serde(rename = "$unflatten=CST")]
     pub codigo_situacao: String,
 }
 
-impl Clone for GrupoPisNt {
-    fn clone(&self) -> Self {
-        Self {
-            codigo_situacao: self.codigo_situacao.clone(),
-        }
-    }
-}
-
 /// Grupo PIS Aliq - Aliq Operações
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct GrupoPisAliq {
     /// CST - Código de Situação Tributária do PIS
     #[serde(rename = "$unflatten=CST")]
@@ -130,15 +112,4 @@ pub struct GrupoPisAliq {
     /// Valor do PIS
     #[serde(rename = "$unflatten=vPIS")]
     pub valor: f32,
-}
-
-impl Clone for GrupoPisAliq {
-    fn clone(&self) -> Self {
-        Self {
-            codigo_situacao: self.codigo_situacao.clone(),
-            valor_base_calculo: self.valor_base_calculo,
-            aliquota: self.aliquota,
-            valor: self.valor,
-        }
-    }
 }

--- a/nfe/src/base/item/imposto/pis.rs
+++ b/nfe/src/base/item/imposto/pis.rs
@@ -1,18 +1,47 @@
 /// Grupos de PIS
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 /// PIS
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq)]
 pub enum GrupoPis {
     /// Outras Operações
-    #[serde(rename = "PISOutr")]
     PisOutr(GrupoPisOutr),
     /// Não Tributado
-    #[serde(rename = "PISNT")]
     PisNt(GrupoPisNt),
     /// Tributado pela alíquota
-    #[serde(rename = "PISAliq")]
     PisAliq(GrupoPisAliq),
+}
+
+impl<'de> Deserialize<'de> for GrupoPis {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+
+        #[derive(Deserialize)]
+        pub enum TipoPis {
+            #[serde(rename = "PISOutr")]
+            PisOutr(GrupoPisOutr),
+            #[serde(rename = "PISNT")]
+            PisNt(GrupoPisNt),
+            #[serde(rename = "PISAliq")]
+            PisAliq(GrupoPisAliq),
+        }
+
+        #[derive(Deserialize)]
+        struct GrupoPisContainer{
+            #[serde(rename = "$value")]
+            inner: TipoPis
+        }
+
+        let gr = GrupoPisContainer::deserialize(deserializer)?;
+
+        Ok(match gr.inner {
+            TipoPis::PisOutr(g) => GrupoPis::PisOutr(g),
+            TipoPis::PisNt(g) => GrupoPis::PisNt(g),
+            TipoPis::PisAliq(g) => GrupoPis::PisAliq(g)
+        })
+    }
 }
 
 /// Grupo PIS Outr - Outras Operações

--- a/nfe/src/base/item/mod.rs
+++ b/nfe/src/base/item/mod.rs
@@ -26,6 +26,6 @@ impl FromStr for Item {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }

--- a/nfe/src/base/item/mod.rs
+++ b/nfe/src/base/item/mod.rs
@@ -11,7 +11,7 @@ pub use imposto::*;
 pub use produto::*;
 
 /// Item da nota
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 #[serde(rename = "det")]
 pub struct Item {
     #[serde(rename = "nItem")]

--- a/nfe/src/base/item/mod.rs
+++ b/nfe/src/base/item/mod.rs
@@ -1,7 +1,7 @@
 //! Detalhamento de produtos e serviços
 
 use super::Error;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 mod imposto;
@@ -11,7 +11,7 @@ pub use imposto::*;
 pub use produto::*;
 
 /// Item da nota
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename = "det")]
 pub struct Item {
     #[serde(rename = "nItem")]
@@ -27,5 +27,11 @@ impl FromStr for Item {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         quick_xml::de::from_str(s).map_err(|e| e.into())
+    }
+}
+
+impl ToString for Item {
+    fn to_string(&self) -> String {
+        quick_xml::se::to_string(self).expect("Falha ao serializar o item")
     }
 }

--- a/nfe/src/base/item/produto.rs
+++ b/nfe/src/base/item/produto.rs
@@ -75,7 +75,7 @@ impl FromStr for Produto {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/item/produto.rs
+++ b/nfe/src/base/item/produto.rs
@@ -1,8 +1,8 @@
 //! Produtos
 
 use super::Error;
-use serde::{Deserialize, Deserializer};
-use serde_repr::Deserialize_repr;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 /// Detalhamento do produto do item
@@ -64,7 +64,7 @@ pub struct ProdutoTributacao {
 }
 
 /// Indicador de Produção em escala relevante
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum EscalaRelevante {
     Sim = 1,
@@ -79,64 +79,18 @@ impl FromStr for Produto {
     }
 }
 
+impl ToString for Produto {
+    fn to_string(&self) -> String {
+        quick_xml::se::to_string(self).expect("Falha ao serializar o produto")
+    }
+}
+
 impl<'de> Deserialize<'de> for Produto {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         // TODO: voltar a tentar usar o serde flatten
-
-        #[derive(Deserialize)]
-        struct ProdContainer {
-            #[serde(rename = "cProd")]
-            pub codigo: String,
-            #[serde(rename = "cEAN")]
-            pub gtin: String,
-            #[serde(rename = "xProd")]
-            pub descricao: String,
-            #[serde(rename = "NCM")]
-            pub ncm: String,
-            #[serde(rename = "CNPJFab")]
-            pub fabricante_cnpj: Option<String>,
-            #[serde(rename = "uCom")]
-            pub unidade: String,
-            #[serde(rename = "qCom")]
-            pub quantidade: f32,
-            #[serde(rename = "vUnCom")]
-            pub valor_unitario: f32,
-            #[serde(rename = "vProd")]
-            pub valor_bruto: f32,
-            #[serde(rename = "vFrete")]
-            pub valor_frete: Option<f32>,
-            #[serde(rename = "vDesc")]
-            pub valor_seguro: Option<f32>,
-            #[serde(rename = "vSeg")]
-            pub valor_desconto: Option<f32>,
-            #[serde(rename = "vOutro")]
-            pub valor_outros: Option<f32>,
-            #[serde(rename = "indTot")]
-            pub valor_compoe_total_nota: bool,
-
-            #[serde(rename = "CEST")]
-            pub t_cest: Option<String>,
-            #[serde(rename = "indEscala")]
-            pub t_escala_relevante: Option<EscalaRelevante>,
-            #[serde(rename = "cBenef")]
-            pub t_codigo_beneficio_fiscal: Option<String>,
-            #[serde(rename = "EXTIPI")]
-            pub t_codigo_excecao_ipi: Option<String>,
-            #[serde(rename = "CFOP")]
-            pub t_cfop: String,
-            #[serde(rename = "cEANTrib")]
-            pub t_gtin: String,
-            #[serde(rename = "uTrib")]
-            pub t_unidade: String,
-            #[serde(rename = "qTrib")]
-            pub t_quantidade: f32,
-            #[serde(rename = "vUnTrib")]
-            pub t_valor_unitario: f32,
-        }
-
         let prod = ProdContainer::deserialize(deserializer)?;
 
         Ok(Self {
@@ -157,7 +111,7 @@ impl<'de> Deserialize<'de> for Produto {
             valor_seguro: prod.valor_seguro,
             valor_desconto: prod.valor_desconto,
             valor_outros: prod.valor_outros,
-            valor_compoe_total_nota: prod.valor_compoe_total_nota,
+            valor_compoe_total_nota: prod.valor_compoe_total_nota == 1,
             tributacao: ProdutoTributacao {
                 cest: prod.t_cest,
                 escala_relevante: prod.t_escala_relevante,
@@ -175,4 +129,106 @@ impl<'de> Deserialize<'de> for Produto {
             },
         })
     }
+}
+
+impl Serialize for Produto {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let prod = ProdContainer {
+            codigo: self.codigo.clone(),
+            gtin: match &self.gtin {
+                Some(gt) => gt.clone(),
+                None => "SEM GTIN".to_string(),
+            },
+            descricao: self.descricao.clone(),
+            ncm: self.ncm.clone(),
+            fabricante_cnpj: self.fabricante_cnpj.clone(),
+            unidade: self.unidade.clone(),
+            quantidade: self.quantidade.clone(),
+            valor_unitario: self.valor_unitario.clone(),
+            valor_bruto: self.valor_bruto,
+            valor_frete: self.valor_frete,
+            valor_seguro: self.valor_seguro,
+            valor_desconto: self.valor_desconto,
+            valor_outros: self.valor_outros,
+            valor_compoe_total_nota: if self.valor_compoe_total_nota { 1 } else { 0 },
+            t_cest: self.tributacao.cest.clone(),
+            t_escala_relevante: self.tributacao.escala_relevante,
+            t_codigo_beneficio_fiscal: self.tributacao.codigo_beneficio_fiscal.clone(),
+            t_codigo_excecao_ipi: self.tributacao.codigo_excecao_ipi.clone(),
+            t_cfop: self.tributacao.cfop.clone(),
+            t_gtin: match &self.tributacao.gtin {
+                Some(gt) => gt.clone(),
+                None => "SEM GTIN".to_string(),
+            },
+            t_unidade: self.tributacao.unidade.clone(),
+            t_quantidade: self.tributacao.quantidade,
+            t_valor_unitario: self.tributacao.valor_unitario,
+        };
+
+        prod.serialize(serializer)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename = "prod")]
+struct ProdContainer {
+    #[serde(rename = "$unflatten=cProd")]
+    pub codigo: String,
+    #[serde(rename = "$unflatten=cEAN")]
+    pub gtin: String,
+    #[serde(rename = "$unflatten=xProd")]
+    pub descricao: String,
+    #[serde(rename = "$unflatten=NCM")]
+    pub ncm: String,
+    #[serde(rename = "$unflatten=CNPJFab")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fabricante_cnpj: Option<String>,
+    #[serde(rename = "$unflatten=uCom")]
+    pub unidade: String,
+    #[serde(rename = "$unflatten=qCom")]
+    pub quantidade: f32,
+    #[serde(rename = "$unflatten=vUnCom")]
+    pub valor_unitario: f32,
+    #[serde(rename = "$unflatten=vProd")]
+    pub valor_bruto: f32,
+    #[serde(rename = "$unflatten=vFrete")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valor_frete: Option<f32>,
+    #[serde(rename = "$unflatten=vDesc")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valor_seguro: Option<f32>,
+    #[serde(rename = "$unflatten=vSeg")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valor_desconto: Option<f32>,
+    #[serde(rename = "$unflatten=vOutro")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valor_outros: Option<f32>,
+    #[serde(rename = "$unflatten=indTot")]
+    pub valor_compoe_total_nota: u8,
+
+    #[serde(rename = "$unflatten=CEST")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub t_cest: Option<String>,
+    #[serde(rename = "$unflatten=indEscala")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub t_escala_relevante: Option<EscalaRelevante>,
+    #[serde(rename = "$unflatten=cBenef")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub t_codigo_beneficio_fiscal: Option<String>,
+    #[serde(rename = "$unflatten=EXTIPI")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub t_codigo_excecao_ipi: Option<String>,
+    #[serde(rename = "$unflatten=CFOP")]
+    pub t_cfop: String,
+    #[serde(rename = "$unflatten=cEANTrib")]
+    pub t_gtin: String,
+    #[serde(rename = "$unflatten=uTrib")]
+    pub t_unidade: String,
+    #[serde(rename = "$unflatten=qTrib")]
+    pub t_quantidade: f32,
+    #[serde(rename = "$unflatten=vUnTrib")]
+    pub t_valor_unitario: f32,
 }

--- a/nfe/src/base/item/produto.rs
+++ b/nfe/src/base/item/produto.rs
@@ -6,7 +6,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 /// Detalhamento do produto do item
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Produto {
     /// Código do produto
     pub codigo: String,
@@ -41,7 +41,7 @@ pub struct Produto {
 }
 
 /// Dados sobre a tributação do produto
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ProdutoTributacao {
     /// CEST - Código Especificador da Substituição Tributária
     pub cest: Option<String>,

--- a/nfe/src/base/mod.rs
+++ b/nfe/src/base/mod.rs
@@ -53,7 +53,7 @@ impl FromStr for Nfe {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/mod.rs
+++ b/nfe/src/base/mod.rs
@@ -3,7 +3,7 @@
 //! Tipos e estruturas para tratamento da NF-e sem
 //! distinção dos modelos.
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Read;
@@ -68,47 +68,18 @@ impl TryFrom<File> for Nfe {
     }
 }
 
+impl ToString for Nfe {
+    fn to_string(&self) -> String {
+        quick_xml::se::to_string(self).expect("Falha ao serializar a nota")
+    }
+}
+
 impl<'de> Deserialize<'de> for Nfe {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(rename = "NFe")]
-        struct NfeRoot {
-            #[serde(rename = "infNFe")]
-            pub inf: NfeHelper,
-        }
-
-        #[derive(Deserialize)]
-        struct InfAdd {
-            #[serde(rename = "infCpl")]
-            pub informacao_complementar: Option<String>,
-        }
-
-        #[derive(Deserialize)]
-        struct NfeHelper {
-            #[serde(rename = "versao")]
-            pub versao: VersaoLayout,
-            #[serde(rename = "Id")]
-            pub chave_acesso: String,
-            #[serde(rename = "ide")]
-            pub ide: Identificacao,
-            #[serde(rename = "emit")]
-            pub emit: Emitente,
-            #[serde(rename = "dest")]
-            pub dest: Option<Destinatario>,
-            #[serde(rename = "det")]
-            pub itens: Vec<Item>,
-            #[serde(rename = "total")]
-            pub totais: Totalizacao,
-            #[serde(rename = "transp")]
-            pub transporte: Transporte,
-            #[serde(rename = "infAdic")]
-            pub add: Option<InfAdd>,
-        }
-
-        let nfe = NfeRoot::deserialize(deserializer)?;
+        let nfe = NfeRootContainer::deserialize(deserializer)?;
 
         Ok(Self {
             versao: nfe.inf.versao,
@@ -125,4 +96,78 @@ impl<'de> Deserialize<'de> for Nfe {
             },
         })
     }
+}
+
+impl Serialize for Nfe {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let inf = NfeInfContainer {
+            versao: self.versao,
+            chave_acesso: format!("NFe{}", self.chave_acesso),
+            ide: self.ide.clone(),
+            emit: self.emit.clone(),
+            dest: self.dest.clone(),
+            itens: self.itens.clone(),
+            totais: self.totais.clone(),
+            transporte: self.transporte.clone(),
+            add: match self.informacao_complementar.clone() {
+                Some(ic) => Some(InfAddContainer {
+                    informacao_complementar: Some(ic),
+                }),
+                None => None,
+            },
+        };
+
+        let root = NfeRootContainer { inf };
+
+        root.serialize(serializer)
+    }
+}
+
+impl Serialize for VersaoLayout {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(match self {
+            VersaoLayout::V4_00 => "4.00",
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename = "NFe")]
+struct NfeRootContainer {
+    #[serde(rename = "infNFe")]
+    pub inf: NfeInfContainer,
+}
+
+#[derive(Deserialize, Serialize)]
+struct InfAddContainer {
+    #[serde(rename = "$unflatten=infCpl")]
+    pub informacao_complementar: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct NfeInfContainer {
+    #[serde(rename = "versao")]
+    pub versao: VersaoLayout,
+    #[serde(rename = "Id")]
+    pub chave_acesso: String,
+    #[serde(rename = "ide")]
+    pub ide: Identificacao,
+    #[serde(rename = "emit")]
+    pub emit: Emitente,
+    #[serde(rename = "dest")]
+    pub dest: Option<Destinatario>,
+    #[serde(rename = "det")]
+    pub itens: Vec<Item>,
+    #[serde(rename = "total")]
+    pub totais: Totalizacao,
+    #[serde(rename = "transp")]
+    pub transporte: Transporte,
+    #[serde(rename = "infAdic")]
+    pub add: Option<InfAddContainer>,
 }

--- a/nfe/src/base/totais.rs
+++ b/nfe/src/base/totais.rs
@@ -35,7 +35,7 @@ impl FromStr for Totalizacao {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/totais.rs
+++ b/nfe/src/base/totais.rs
@@ -1,7 +1,7 @@
 //! Totalização dos produtos e serviços
 
 use super::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
 /// Totalização da nota fiscal
@@ -39,44 +39,42 @@ impl FromStr for Totalizacao {
     }
 }
 
+impl ToString for Totalizacao {
+    fn to_string(&self) -> String {
+        serde_xml_rs::to_string(self).expect("Falha ao serializar a totalização")
+    }
+}
+
+impl Serialize for Totalizacao {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let icms = IcmsTot {
+            valor_base_calculo: self.valor_base_calculo,
+            valor_icms: self.valor_icms,
+            valor_produtos: self.valor_produtos,
+            valor_frete: self.valor_frete,
+            valor_seguro: self.valor_seguro,
+            valor_desconto: self.valor_desconto,
+            valor_outros: self.valor_outros,
+            valor_pis: self.valor_pis,
+            valor_cofins: self.valor_cofins,
+            valor_total: self.valor_total,
+            valor_aproximado_tributos: self.valor_aproximado_tributos,
+        };
+
+        let total = TotalContainer { icms };
+
+        total.serialize(serializer)
+    }
+}
+
 impl<'de> Deserialize<'de> for Totalizacao {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(rename = "total")]
-        struct TotalContainer {
-            #[serde(rename = "ICMSTot")]
-            icms: IcmsTot,
-        }
-
-        #[derive(Deserialize)]
-        struct IcmsTot {
-            #[serde(rename = "vBC")]
-            valor_base_calculo: f32,
-            #[serde(rename = "vICMS")]
-            valor_icms: f32,
-            #[serde(rename = "vProd")]
-            valor_produtos: f32,
-            #[serde(rename = "vFrete")]
-            valor_frete: f32,
-            #[serde(rename = "vSeg")]
-            valor_seguro: f32,
-            #[serde(rename = "vDesc")]
-            valor_desconto: f32,
-            #[serde(rename = "vOutro")]
-            valor_outros: f32,
-            #[serde(rename = "vPIS")]
-            valor_pis: f32,
-            #[serde(rename = "vCOFINS")]
-            valor_cofins: f32,
-            #[serde(rename = "vNF")]
-            valor_total: f32,
-            #[serde(rename = "vTotTrib")]
-            valor_aproximado_tributos: f32,
-        }
-
         let helper = TotalContainer::deserialize(deserializer)?;
         Ok(Totalizacao {
             valor_base_calculo: helper.icms.valor_base_calculo,
@@ -91,5 +89,59 @@ impl<'de> Deserialize<'de> for Totalizacao {
             valor_total: helper.icms.valor_total,
             valor_aproximado_tributos: helper.icms.valor_aproximado_tributos,
         })
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename = "total")]
+struct TotalContainer {
+    #[serde(rename = "ICMSTot")]
+    icms: IcmsTot,
+}
+
+#[derive(Deserialize)]
+struct IcmsTot {
+    #[serde(rename = "vBC")]
+    valor_base_calculo: f32,
+    #[serde(rename = "vICMS")]
+    valor_icms: f32,
+    #[serde(rename = "vProd")]
+    valor_produtos: f32,
+    #[serde(rename = "vFrete")]
+    valor_frete: f32,
+    #[serde(rename = "vSeg")]
+    valor_seguro: f32,
+    #[serde(rename = "vDesc")]
+    valor_desconto: f32,
+    #[serde(rename = "vOutro")]
+    valor_outros: f32,
+    #[serde(rename = "vPIS")]
+    valor_pis: f32,
+    #[serde(rename = "vCOFINS")]
+    valor_cofins: f32,
+    #[serde(rename = "vNF")]
+    valor_total: f32,
+    #[serde(rename = "vTotTrib")]
+    valor_aproximado_tributos: f32,
+}
+
+impl Serialize for IcmsTot {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(11))?;
+        map.serialize_entry("vBC", &self.valor_base_calculo)?;
+        map.serialize_entry("vICMS", &self.valor_icms)?;
+        map.serialize_entry("vProd", &self.valor_produtos)?;
+        map.serialize_entry("vFrete", &self.valor_frete)?;
+        map.serialize_entry("vSeg", &self.valor_seguro)?;
+        map.serialize_entry("vDesc", &self.valor_desconto)?;
+        map.serialize_entry("vOutro", &self.valor_outros)?;
+        map.serialize_entry("vPIS", &self.valor_pis)?;
+        map.serialize_entry("vCOFINS", &self.valor_cofins)?;
+        map.serialize_entry("vNF", &self.valor_total)?;
+        map.serialize_entry("vTotTrib", &self.valor_aproximado_tributos)?;
+        map.end()
     }
 }

--- a/nfe/src/base/totais.rs
+++ b/nfe/src/base/totais.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
 /// Totalização da nota fiscal
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Totalizacao {
     /// Base de cálculo do ICMS
     pub valor_base_calculo: f32,

--- a/nfe/src/base/totais.rs
+++ b/nfe/src/base/totais.rs
@@ -1,7 +1,7 @@
 //! Totalização dos produtos e serviços
 
 use super::Error;
-use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
 /// Totalização da nota fiscal
@@ -41,7 +41,7 @@ impl FromStr for Totalizacao {
 
 impl ToString for Totalizacao {
     fn to_string(&self) -> String {
-        serde_xml_rs::to_string(self).expect("Falha ao serializar a totalização")
+        quick_xml::se::to_string(self).expect("Falha ao serializar a totalização")
     }
 }
 
@@ -99,49 +99,28 @@ struct TotalContainer {
     icms: IcmsTot,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct IcmsTot {
-    #[serde(rename = "vBC")]
+    #[serde(rename = "$unflatten=vBC")]
     valor_base_calculo: f32,
-    #[serde(rename = "vICMS")]
+    #[serde(rename = "$unflatten=vICMS")]
     valor_icms: f32,
-    #[serde(rename = "vProd")]
+    #[serde(rename = "$unflatten=vProd")]
     valor_produtos: f32,
-    #[serde(rename = "vFrete")]
+    #[serde(rename = "$unflatten=vFrete")]
     valor_frete: f32,
-    #[serde(rename = "vSeg")]
+    #[serde(rename = "$unflatten=vSeg")]
     valor_seguro: f32,
-    #[serde(rename = "vDesc")]
+    #[serde(rename = "$unflatten=vDesc")]
     valor_desconto: f32,
-    #[serde(rename = "vOutro")]
+    #[serde(rename = "$unflatten=vOutro")]
     valor_outros: f32,
-    #[serde(rename = "vPIS")]
+    #[serde(rename = "$unflatten=vPIS")]
     valor_pis: f32,
-    #[serde(rename = "vCOFINS")]
+    #[serde(rename = "$unflatten=vCOFINS")]
     valor_cofins: f32,
-    #[serde(rename = "vNF")]
+    #[serde(rename = "$unflatten=vNF")]
     valor_total: f32,
-    #[serde(rename = "vTotTrib")]
+    #[serde(rename = "$unflatten=vTotTrib")]
     valor_aproximado_tributos: f32,
-}
-
-impl Serialize for IcmsTot {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(11))?;
-        map.serialize_entry("vBC", &self.valor_base_calculo)?;
-        map.serialize_entry("vICMS", &self.valor_icms)?;
-        map.serialize_entry("vProd", &self.valor_produtos)?;
-        map.serialize_entry("vFrete", &self.valor_frete)?;
-        map.serialize_entry("vSeg", &self.valor_seguro)?;
-        map.serialize_entry("vDesc", &self.valor_desconto)?;
-        map.serialize_entry("vOutro", &self.valor_outros)?;
-        map.serialize_entry("vPIS", &self.valor_pis)?;
-        map.serialize_entry("vCOFINS", &self.valor_cofins)?;
-        map.serialize_entry("vNF", &self.valor_total)?;
-        map.serialize_entry("vTotTrib", &self.valor_aproximado_tributos)?;
-        map.end()
-    }
 }

--- a/nfe/src/base/transporte.rs
+++ b/nfe/src/base/transporte.rs
@@ -18,7 +18,7 @@ impl FromStr for Transporte {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_xml_rs::from_str(s).map_err(|e| e.into())
+        quick_xml::de::from_str(s).map_err(|e| e.into())
     }
 }
 

--- a/nfe/src/base/transporte.rs
+++ b/nfe/src/base/transporte.rs
@@ -6,7 +6,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 /// Transporte da nota
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, Clone)]
 #[serde(rename = "transp")]
 pub struct Transporte {
     /// Modalidade do frete

--- a/nfe/src/base/transporte.rs
+++ b/nfe/src/base/transporte.rs
@@ -1,12 +1,12 @@
 //! Informações sobre o transporte da nota
 
 use super::Error;
-use serde::Deserialize;
-use serde_repr::Deserialize_repr;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 /// Transporte da nota
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename = "transp")]
 pub struct Transporte {
     /// Modalidade do frete
@@ -22,8 +22,14 @@ impl FromStr for Transporte {
     }
 }
 
+impl ToString for Transporte {
+    fn to_string(&self) -> String {
+        serde_xml_rs::to_string(self).expect("Falha ao serializar o transporte")
+    }
+}
+
 /// Modalidade do frete
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum ModalidadeFrete {
     /// CIF - Contratação do frete por conta do remetente

--- a/nfe/src/base/transporte.rs
+++ b/nfe/src/base/transporte.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 #[serde(rename = "transp")]
 pub struct Transporte {
     /// Modalidade do frete
-    #[serde(rename = "modFrete")]
+    #[serde(rename = "$unflatten=modFrete")]
     pub modalidade: ModalidadeFrete,
 }
 
@@ -24,7 +24,7 @@ impl FromStr for Transporte {
 
 impl ToString for Transporte {
     fn to_string(&self) -> String {
-        serde_xml_rs::to_string(self).expect("Falha ao serializar o transporte")
+        quick_xml::se::to_string(self).expect("Falha ao serializar o transporte")
     }
 }
 

--- a/nfe/src/modelos/nfe/dest.rs
+++ b/nfe/src/modelos/nfe/dest.rs
@@ -1,4 +1,4 @@
-//! Destinarário da NF-e no modelo 55
+//! Destinatário da NF-e no modelo 55
 
 use super::Error;
 use crate::base::dest::Destinatario as DestinatarioBase;

--- a/nfe/src/modelos/nfe/dest.rs
+++ b/nfe/src/modelos/nfe/dest.rs
@@ -38,6 +38,18 @@ impl TryFrom<DestinatarioBase> for Destinatario {
     }
 }
 
+impl From<&Destinatario> for DestinatarioBase {
+    fn from(dest: &Destinatario) -> Self {
+        Self {
+            cnpj: dest.cnpj.clone(),
+            razao_social: Some(dest.razao_social.clone()),
+            endereco: Some(dest.endereco.clone()),
+            ie: dest.ie.clone(),
+            indicador_ie: dest.indicador_ie,
+        }
+    }
+}
+
 impl FromStr for Destinatario {
     type Err = Error;
 
@@ -45,5 +57,13 @@ impl FromStr for Destinatario {
         let base = s.parse::<DestinatarioBase>()?;
 
         base.try_into()
+    }
+}
+
+impl ToString for Destinatario {
+    fn to_string(&self) -> String {
+        let base: DestinatarioBase = self.into();
+
+        base.to_string()
     }
 }

--- a/nfe/src/modelos/nfe/mod.rs
+++ b/nfe/src/modelos/nfe/mod.rs
@@ -1,5 +1,6 @@
 //! Modelo 55 da NF-e
 
+use crate::base::dest::Destinatario as DestinatarioBase;
 pub use crate::base::emit::*;
 pub use crate::base::endereco::*;
 pub use crate::base::ide::*;
@@ -60,6 +61,24 @@ impl TryFrom<NfeBase> for Nfe {
     }
 }
 
+impl From<&Nfe> for NfeBase {
+    fn from(doc: &Nfe) -> Self {
+        let dest: DestinatarioBase = (&doc.dest).into();
+
+        Self {
+            versao: doc.versao.clone(),
+            chave_acesso: doc.chave_acesso.clone(),
+            ide: doc.ide.clone(),
+            emit: doc.emit.clone(),
+            dest: Some(dest),
+            itens: doc.itens.clone(),
+            totais: doc.totais.clone(),
+            transporte: doc.transporte.clone(),
+            informacao_complementar: doc.informacao_complementar.clone(),
+        }
+    }
+}
+
 impl FromStr for Nfe {
     type Err = Error;
 
@@ -73,5 +92,13 @@ impl TryFrom<File> for Nfe {
 
     fn try_from(f: File) -> Result<Self, Self::Error> {
         NfeBase::try_from(f)?.try_into()
+    }
+}
+
+impl ToString for Nfe {
+    fn to_string(&self) -> String {
+        let base: NfeBase = self.into();
+
+        base.to_string()
     }
 }

--- a/nfe/src/tests/dest.rs
+++ b/nfe/src/tests/dest.rs
@@ -24,7 +24,7 @@ fn from_instance() -> Result<(), String> {
     assert_eq!(3550308, dest.endereco.codigo_municipio);
     assert_eq!("SAO PAULO", dest.endereco.nome_municipio);
     assert_eq!("SP", dest.endereco.sigla_uf);
-    assert_eq!(04207040, dest.endereco.cep);
+    assert_eq!("04207040", dest.endereco.cep);
     assert_eq!(Some("5190909090".to_string()), dest.endereco.telefone);
 
     Ok(())
@@ -69,8 +69,41 @@ fn manual() -> Result<(), Error> {
     assert_eq!(3550308, dest.endereco.codigo_municipio);
     assert_eq!("SAO PAULO", dest.endereco.nome_municipio);
     assert_eq!("SP", dest.endereco.sigla_uf);
-    assert_eq!(04207040, dest.endereco.cep);
+    assert_eq!("04207040", dest.endereco.cep);
     assert_eq!(Some("5190909090".to_string()), dest.endereco.telefone);
+
+    Ok(())
+}
+
+#[test]
+fn to_string() -> Result<(), Error> {
+    let mut xml_original = "
+        <dest>
+            <CNPJ>58716523000119</CNPJ>
+            <xNome>HOMOLOGACAO</xNome>
+            <enderDest>
+                <xLgr>Av.Teste</xLgr>
+                <nro>2040</nro>
+                <xBairro>Centro</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>Guarulhos</xMun>
+                <UF>SP</UF>
+                <CEP>04207040</CEP>
+                <cPais>1058</cPais>
+                <xPais>BRASIL</xPais>
+                <fone>5190909090</fone>
+            </enderDest>
+            <IE>112006603110</IE>
+            <indIEDest>1</indIEDest>
+        </dest>
+    "
+    .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let destinatario = xml_original.parse::<Destinatario>()?;
+    let xml_novo = destinatario.to_string();
+
+    assert_eq!(xml_original, xml_novo);
 
     Ok(())
 }

--- a/nfe/src/tests/emit.rs
+++ b/nfe/src/tests/emit.rs
@@ -22,7 +22,7 @@ fn from_instance() -> Result<(), String> {
     assert_eq!(4319901, emit.endereco.codigo_municipio);
     assert_eq!("SAPIRANGA", emit.endereco.nome_municipio);
     assert_eq!("RS", emit.endereco.sigla_uf);
-    assert_eq!(93800000, emit.endereco.cep);
+    assert_eq!("93800000", emit.endereco.cep);
     assert_eq!(Some("5190909090".to_string()), emit.endereco.telefone);
 
     Ok(())
@@ -66,7 +66,7 @@ fn manual() -> Result<(), Error> {
     assert_eq!(4319901, emit.endereco.codigo_municipio);
     assert_eq!("SAPIRANGA", emit.endereco.nome_municipio);
     assert_eq!("RS", emit.endereco.sigla_uf);
-    assert_eq!(93800000, emit.endereco.cep);
+    assert_eq!("93800000", emit.endereco.cep);
     assert_eq!(Some("5190909090".to_string()), emit.endereco.telefone);
 
     Ok(())

--- a/nfe/src/tests/emit.rs
+++ b/nfe/src/tests/emit.rs
@@ -94,7 +94,7 @@ fn to_string() -> Result<(), Error> {
             </enderEmit>
         </emit>
     "
-        .to_string();
+    .to_string();
     xml_original.retain(|c| c != '\n' && c != ' ');
 
     let emitente = xml_original.parse::<Emitente>()?;

--- a/nfe/src/tests/emit.rs
+++ b/nfe/src/tests/emit.rs
@@ -71,3 +71,36 @@ fn manual() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn to_string() -> Result<(), Error> {
+    let mut xml_original = "
+        <emit>
+            <CNPJ>06929383000163</CNPJ>
+            <xNome>QUALQUER</xNome>
+            <IE>0018000762</IE>
+            <enderEmit>
+                <xLgr>Testes</xLgr>
+                <nro>1020</nro>
+                <xCpl>0</xCpl>
+                <xBairro>Centro</xBairro>
+                <cMun>4319901</cMun>
+                <xMun>SAPIRANGA</xMun>
+                <UF>RS</UF>
+                <CEP>93800000</CEP>
+                <cPais>1058</cPais>
+                <xPais>BRASIL</xPais>
+                <fone>5190909090</fone>
+            </enderEmit>
+        </emit>
+    "
+        .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let emitente = xml_original.parse::<Emitente>()?;
+    let xml_novo = emitente.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/endereco.rs
+++ b/nfe/src/tests/endereco.rs
@@ -26,7 +26,7 @@ fn emitente() -> Result<(), Error> {
     assert_eq!(4319901, endereco.codigo_municipio);
     assert_eq!("SAPIRANGA", endereco.nome_municipio);
     assert_eq!("RS", endereco.sigla_uf);
-    assert_eq!(93800000, endereco.cep);
+    assert_eq!("93800000", endereco.cep);
     assert_eq!(Some("5190909090".to_string()), endereco.telefone);
 
     Ok(())
@@ -55,7 +55,7 @@ fn destinatario() -> Result<(), Error> {
     assert_eq!(3550308, endereco.codigo_municipio);
     assert_eq!("SAO PAULO", endereco.nome_municipio);
     assert_eq!("SP", endereco.sigla_uf);
-    assert_eq!(04207040, endereco.cep);
+    assert_eq!("04207040", endereco.cep);
     assert_eq!(Some("5190909090".to_string()), endereco.telefone);
 
     Ok(())
@@ -81,6 +81,7 @@ fn to_string() -> Result<(), Error> {
 
     let endereco = xml_original.parse::<Endereco>()?;
     let xml_novo = endereco.to_string();
+    let xml_novo = format!("<Endereco>{}</Endereco>", xml_novo);
 
     assert_eq!(xml_original, xml_novo);
 

--- a/nfe/src/tests/endereco.rs
+++ b/nfe/src/tests/endereco.rs
@@ -81,7 +81,6 @@ fn to_string() -> Result<(), Error> {
 
     let endereco = xml_original.parse::<Endereco>()?;
     let xml_novo = endereco.to_string();
-    let xml_novo = format!("<Endereco>{}</Endereco>", xml_novo);
 
     assert_eq!(xml_original, xml_novo);
 

--- a/nfe/src/tests/endereco.rs
+++ b/nfe/src/tests/endereco.rs
@@ -60,3 +60,29 @@ fn destinatario() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn to_string() -> Result<(), Error> {
+    let mut xml_original = "<Endereco>
+        <xLgr>Rua</xLgr>
+        <nro>1020</nro>
+        <xCpl>0</xCpl>
+        <xBairro>Centro</xBairro>
+        <cMun>4319901</cMun>
+        <xMun>SAPIRANGA</xMun>
+        <UF>RS</UF>
+        <CEP>93800000</CEP>
+        <cPais>1058</cPais>
+        <xPais>BRASIL</xPais>
+        <fone>5190909090</fone>
+    </Endereco>"
+        .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let endereco = xml_original.parse::<Endereco>()?;
+    let xml_novo = endereco.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/ide.rs
+++ b/nfe/src/tests/ide.rs
@@ -18,7 +18,7 @@ fn from_instance() -> Result<(), String> {
     assert_eq!(ModeloDocumentoFiscal::Nfe, ide.modelo);
     assert_eq!(FormatoImpressaoDanfe::NormalRetrato, ide.formato_danfe);
     assert_eq!(TipoAmbiente::Homologacao, ide.ambiente);
-    assert_eq!(1030, ide.chave.codigo);
+    assert_eq!("00001030", ide.chave.codigo);
     assert_eq!(1, ide.chave.digito_verificador);
 
     Ok(())
@@ -35,7 +35,7 @@ fn manual() -> Result<(), Error> {
     assert_eq!(ModeloDocumentoFiscal::Nfe, ide.modelo);
     assert_eq!(FormatoImpressaoDanfe::NormalRetrato, ide.formato_danfe);
     assert_eq!(TipoAmbiente::Homologacao, ide.ambiente);
-    assert_eq!(1030, ide.chave.codigo);
+    assert_eq!("00001030", ide.chave.codigo);
     assert_eq!(1, ide.chave.digito_verificador);
 
     Ok(())
@@ -45,22 +45,6 @@ fn manual() -> Result<(), Error> {
 fn emissao_from_instance() -> Result<(), String> {
     let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
     let emissao = Nfe::try_from(f).map_err(|e| e.to_string())?.ide.emissao;
-
-    assert_eq!(Utc.ymd(2018, 09, 25).and_hms(3, 0, 0), emissao.horario);
-    assert_eq!(TipoEmissao::Normal, emissao.tipo);
-    assert_eq!(FinalidadeEmissao::Normal, emissao.finalidade);
-    assert_eq!(
-        TipoProcessoEmissao::ViaAplicativoDoContribuinte,
-        emissao.processo
-    );
-    assert_eq!("fernando", emissao.versao_processo);
-
-    Ok(())
-}
-
-#[test]
-fn emissao_manual() -> Result<(), Error> {
-    let emissao = XML_MANUAL.parse::<Emissao>()?;
 
     assert_eq!(Utc.ymd(2018, 09, 25).and_hms(3, 0, 0), emissao.horario);
     assert_eq!(TipoEmissao::Normal, emissao.tipo);
@@ -94,19 +78,14 @@ fn operacao_from_instance() -> Result<(), String> {
 }
 
 #[test]
-fn operacao_manual() -> Result<(), Error> {
-    let operacao = XML_MANUAL.parse::<Operacao>()?;
+fn to_string() -> Result<(), Error> {
+    let mut xml_original = XML_MANUAL.to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
 
-    assert_eq!("Venda de producao do estabelecimento", operacao.natureza);
-    assert_eq!(
-        Some(Utc.ymd(2018, 09, 25).and_hms(18, 14, 0)),
-        operacao.horario
-    );
-    assert_eq!(TipoOperacao::Saida, operacao.tipo);
-    assert_eq!(DestinoOperacao::Interestadual, operacao.destino);
-    assert_eq!(TipoConsumidor::Normal, operacao.consumidor);
-    assert_eq!(TipoPresencaComprador::Presencial, operacao.presenca);
-    assert_eq!(None, operacao.intermediador);
+    let ide = xml_original.parse::<Identificacao>()?;
+    let xml_novo = ide.to_string();
+
+    assert_eq!(xml_original, xml_novo);
 
     Ok(())
 }
@@ -114,24 +93,24 @@ fn operacao_manual() -> Result<(), Error> {
 const XML_MANUAL: &str = "
     <ide>
         <cUF>43</cUF>
-        <cNF>00001030</cNF>
-        <natOp>Venda de producao do estabelecimento</natOp>
-        <mod>55</mod>
-        <serie>1</serie>
         <nNF>26</nNF>
-        <dhEmi>2018-09-25T00:00:00-03:00</dhEmi>
-        <dhSaiEnt>2018-09-25T15:14:00-03:00</dhSaiEnt>
-        <tpNF>1</tpNF>
-        <idDest>2</idDest>
+        <serie>1</serie>
+        <mod>55</mod>
         <cMunFG>4307609</cMunFG>
         <tpImp>1</tpImp>
-        <tpEmis>1</tpEmis>
-        <cDV>1</cDV>
         <tpAmb>2</tpAmb>
+        <cNF>00001030</cNF>
+        <cDV>1</cDV>
+        <dhEmi>2018-09-25T03:00:00+00:00</dhEmi>
+        <tpEmis>1</tpEmis>
         <finNFe>1</finNFe>
-        <indFinal>0</indFinal>
-        <indPres>1</indPres>
         <procEmi>0</procEmi>
         <verProc>fernando</verProc>
+        <dhSaiEnt>2018-09-25T18:14:00+00:00</dhSaiEnt>
+        <tpNF>1</tpNF>
+        <idDest>2</idDest>
+        <natOp>Venda de producao do estabelecimento</natOp>
+        <indFinal>0</indFinal>
+        <indPres>1</indPres>
     </ide>
 ";

--- a/nfe/src/tests/infnfe.rs
+++ b/nfe/src/tests/infnfe.rs
@@ -33,3 +33,62 @@ fn informacao_complementar_from_instance() -> Result<(), String> {
 
     Ok(())
 }
+
+#[test]
+fn base_to_string() -> Result<(), String> {
+    let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
+    let nfe = NfeBase::try_from(f).map_err(|e| e.to_string())?;
+
+    let xml_novo = nfe.to_string();
+
+    assert!(xml_novo.contains(
+        "<infNFe versao=\"4.00\" Id=\"NFe29181033657677000156650010001654399001654399\">"
+    ));
+    println!("{}", xml_novo);
+    assert!(xml_novo.contains("<infAdic><infCpl>11899318;422-JERK DIONNY;CLIENTE RECUSOU INFORMAR CPF/CNPJ NO CUPOM</infCpl></infAdic>"));
+
+    Ok(())
+}
+
+#[test]
+fn to_string() -> Result<(), String> {
+    let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
+    let nfe = Nfe::try_from(f).map_err(|e| e.to_string())?;
+
+    let xml_novo = nfe.to_string();
+
+    assert!(xml_novo.contains(
+        "<infNFe versao=\"4.00\" Id=\"NFe43180906929383000163550010000000261000010301\">"
+    ));
+    assert!(!xml_novo.contains("<infAdic>"));
+
+    Ok(())
+}
+
+#[test]
+fn parse_to_string_parse_to_string() -> Result<(), String> {
+    let f = File::open("xmls/nfe_layout4.xml").map_err(|e| e.to_string())?;
+    let nfe1 = Nfe::try_from(f).map_err(|e| e.to_string())?;
+    let xml1 = nfe1.to_string();
+
+    let nfe2 = xml1.parse::<Nfe>().map_err(|e| e.to_string())?;
+    let xml2 = nfe2.to_string();
+
+    assert_eq!(xml1, xml2);
+
+    Ok(())
+}
+
+#[test]
+fn base_parse_to_string_parse_to_string() -> Result<(), String> {
+    let f = File::open("xmls/nfce_layout4.xml").map_err(|e| e.to_string())?;
+    let nfe1 = NfeBase::try_from(f).map_err(|e| e.to_string())?;
+    let xml1 = nfe1.to_string();
+
+    let nfe2 = xml1.parse::<NfeBase>().map_err(|e| e.to_string())?;
+    let xml2 = nfe2.to_string();
+
+    assert_eq!(xml1, xml2);
+
+    Ok(())
+}

--- a/nfe/src/tests/itens.rs
+++ b/nfe/src/tests/itens.rs
@@ -380,3 +380,33 @@ fn impostos() -> Result<(), String> {
 
     Ok(())
 }
+
+#[test]
+fn produto_to_string() -> Result<(), Error> {
+    let mut xml_original = "<prod>
+        <cProd>11007</cProd>
+        <cEAN>SEM GTIN</cEAN>
+        <xProd>UM PRODUTO TESTE QUALQUER</xProd>
+        <NCM>64011000</NCM>
+        <uCom>UN</uCom>
+        <qCom>10</qCom>
+        <vUnCom>50</vUnCom>
+        <vProd>500</vProd>
+        <indTot>1</indTot>
+        <CEST>1234567</CEST>
+        <CFOP>6101</CFOP>
+        <cEANTrib>SEM GTIN</cEANTrib>
+        <uTrib>UN</uTrib>
+        <qTrib>10</qTrib>
+        <vUnTrib>50</vUnTrib>
+    </prod>"
+        .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let produto = xml_original.parse::<Produto>()?;
+    let xml_novo = produto.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/itens.rs
+++ b/nfe/src/tests/itens.rs
@@ -410,3 +410,43 @@ fn produto_to_string() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn imposto_to_string() -> Result<(), Error> {
+    let mut xml_original = "<imposto>
+            <vTotTrib>0</vTotTrib>
+            <ICMS>
+                <ICMSSN202>
+                    <orig>0</orig>
+                    <CSOSN>202</CSOSN>
+                    <modBCST>4</modBCST>
+                    <vBCST>0</vBCST>
+                    <pICMSST>0</pICMSST>
+                    <vICMSST>0</vICMSST>
+                </ICMSSN202>
+            </ICMS>
+            <PIS>
+                <PISOutr>
+                    <CST>49</CST>
+                    <vBC>0</vBC>
+                    <pPIS>0</pPIS>
+                </PISOutr>
+            </PIS>
+            <COFINS>
+                <COFINSOutr>
+                    <CST>49</CST>
+                    <vBC>0</vBC>
+                    <pCOFINS>0</pCOFINS>
+                </COFINSOutr>
+            </COFINS>
+        </imposto>"
+        .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let imposto = xml_original.parse::<Imposto>()?;
+    let xml_novo = imposto.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/itens.rs
+++ b/nfe/src/tests/itens.rs
@@ -450,3 +450,40 @@ fn imposto_to_string() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn to_string() -> Result<(), Error> {
+    let mut xml_original = "
+        <det nItem=\"1\">
+            <prod>
+                <cProd>11007</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>UM PRODUTO TESTE QUALQUER</xProd>
+                <NCM>64011000</NCM>
+                <uCom>UN</uCom>
+                <qCom>10</qCom>
+                <vUnCom>50</vUnCom>
+                <vProd>500</vProd>
+                <indTot>1</indTot>
+                <CEST>1234567</CEST>
+                <CFOP>6101</CFOP>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>UN</uTrib>
+                <qTrib>10</qTrib>
+                <vUnTrib>50</vUnTrib>
+            </prod>
+            <imposto>
+                <vTotTrib>0</vTotTrib>
+            </imposto>
+       </det>"
+        .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+    xml_original = xml_original.replace("detnItem", "det nItem");
+
+    let item = xml_original.parse::<Item>()?;
+    let xml_novo = item.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/totais.rs
+++ b/nfe/src/tests/totais.rs
@@ -89,3 +89,31 @@ fn manual_produtos_com_pis_cofins() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn to_string() -> Result<(), Error> {
+    let mut xml_original = "<total>
+            <ICMSTot>
+                <vBC>0</vBC>
+                <vICMS>0</vICMS>
+                <vProd>150</vProd>
+                <vFrete>0</vFrete>
+                <vSeg>0</vSeg>
+                <vDesc>0</vDesc>
+                <vOutro>10</vOutro>
+                <vPIS>0.89</vPIS>
+                <vCOFINS>4.09</vCOFINS>
+                <vNF>150</vNF>
+                <vTotTrib>35.75</vTotTrib>
+            </ICMSTot>
+        </total>"
+        .to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let totalizacao = xml_original.parse::<Totalizacao>()?;
+    let xml_novo = totalizacao.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/transporte.rs
+++ b/nfe/src/tests/transporte.rs
@@ -25,3 +25,17 @@ fn manual() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn to_string() -> Result<(), Error> {
+
+    let mut xml_original = "<transp><modFrete>9</modFrete></transp>".to_string();
+    xml_original.retain(|c| c != '\n' && c != ' ');
+
+    let transporte = xml_original.parse::<Transporte>()?;
+    let xml_novo = transporte.to_string();
+
+    assert_eq!(xml_original, xml_novo);
+
+    Ok(())
+}

--- a/nfe/src/tests/transporte.rs
+++ b/nfe/src/tests/transporte.rs
@@ -28,7 +28,6 @@ fn manual() -> Result<(), Error> {
 
 #[test]
 fn to_string() -> Result<(), Error> {
-
     let mut xml_original = "<transp><modFrete>9</modFrete></transp>".to_string();
     xml_original.retain(|c| c != '\n' && c != ' ');
 


### PR DESCRIPTION
Implementação da serialização da nfe. Foi necessário mudar a crate usada para lidar com o XML. Consegui organizar melhor o fonte envolvido na serialização, mas ainda sim há o uso de structs auxiliares. 